### PR TITLE
Add functions to read and write jetto.in

### DIFF
--- a/duqtools/io.py
+++ b/duqtools/io.py
@@ -1,4 +1,9 @@
-import imas
+import f90nml
+
+try:
+    import imas
+except ImportError:
+    pass
 
 
 def fetch_ids_data(
@@ -7,7 +12,7 @@ def fetch_ids_data(
     run: int,
     user_name: str,
     db_name: str,
-) -> imas.DBEntry:
+) -> 'imas.DBEntry':
     """Fetch entry from IMAS database.
 
     e.g.
@@ -47,3 +52,35 @@ def fetch_ids_data(
     )
 
     return db
+
+
+def read_jetto_in(path: str) -> dict:
+    """Read jetto.in (fortran namelist).
+
+    TODO: is the header in jetto.in important?
+
+    Parameters
+    ----------
+    path : str
+        Path to jetto.in namelist
+
+    Returns
+    -------
+    namelist : f90nml.Namelist
+        Returns parameters in jetto.in as Namelist
+    """
+    return f90nml.read(path)
+
+
+def write_jetto_in(path: str, namelist: dict):
+    """Write dictionary to jetto.in file.
+
+    Parameters
+    ----------
+    path : str
+        Path to jetto.in namelist
+    namelist : dict
+        Fortran namelist in dictionary format
+    """
+    nml = f90nml.Namelist(namelist)
+    nml.write(path)

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
+    f90nml
     imas
     numpy
     pydantic

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,21 +1,28 @@
-from duqtools.io import read_jetto_in, write_jetto_in
+from duqtools.io import patch_namelist, read_namelist, write_namelist
+
+nml = {'nlist1': {'a': 123, 'b': 456}, 'nlist2': {'c': [1, 2, 3], 'd': None}}
 
 
-def test_jetto_in_io(tmp_path):
-    nml = {
-        'nlist1': {
-            'a': 123,
-            'b': 456
-        },
-        'nlist2': {
-            'c': [1, 2, 3],
-            'd': None
-        }
-    }
+def test_namelist_io(tmp_path):
+    path = tmp_path / 'jetto.in'
 
-    jetto_in = tmp_path / 'jetto.in'
-
-    write_jetto_in(jetto_in, nml)
-    nml2 = read_jetto_in(jetto_in)
+    write_namelist(path, nml)
+    nml2 = read_namelist(path)
 
     assert nml == nml2
+
+
+def test_patch_namelist(tmp_path):
+    path = tmp_path / 'jetto.in'
+    out = tmp_path / 'patched_jetto.in'
+
+    patch = {'nlist1': {'a': 321}, 'nlist3': {'e': 'asdf'}}
+
+    write_namelist(path, nml)
+    patched = patch_namelist(path, patch, out)
+
+    assert out.exists()
+    expected_nlist1 = {**nml['nlist1'], **patch['nlist1']}
+    assert patched['nlist1'] == expected_nlist1
+    assert patched['nlist2'] == nml['nlist2']
+    assert patched['nlist3'] == patch['nlist3']

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,21 @@
+from duqtools.io import read_jetto_in, write_jetto_in
+
+
+def test_jetto_in_io(tmp_path):
+    nml = {
+        'nlist1': {
+            'a': 123,
+            'b': 456
+        },
+        'nlist2': {
+            'c': [1, 2, 3],
+            'd': None
+        }
+    }
+
+    jetto_in = tmp_path / 'jetto.in'
+
+    write_jetto_in(jetto_in, nml)
+    nml2 = read_jetto_in(jetto_in)
+
+    assert nml == nml2


### PR DESCRIPTION
This PR adds functions to read / write fortran namelists (`jetto.in`). It uses `f90nml`, which I added to the `setup.cfg`.

## TODO
- [x] Check whether jetto needs the header info -> this is necessary
