### PR TITLE
Fix branch name in workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,9 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
-      - master
+      - main
     types:
       - opened
       - reopened


### PR DESCRIPTION
The test workflow fails because the branch is set to `master`, we use `main`.