### PR TITLE
Interface jintrac python config vars

### DIFF
--- a/duqtools/jetto/__init__.py
+++ b/duqtools/jetto/__init__.py
@@ -1,6 +1,6 @@
 """This module contains tools for interfacing with jetto runs."""
 
-from ._jset import read_jset, write_jset
+from ._jset import JettoSettings, read_jset, write_jset
 from ._namelist import patch_namelist, read_namelist, write_namelist
 
 __all__ = [
@@ -9,4 +9,5 @@ __all__ = [
     'write_namelist',
     'read_jset',
     'write_jset',
+    'JettoSettings',
 ]

--- a/duqtools/jetto/_jset.py
+++ b/duqtools/jetto/_jset.py
@@ -1,4 +1,5 @@
 """Functions to interface with `jetto.jset` files."""
+from __future__ import annotations
 
 from typing import Dict, List, TextIO, Tuple
 
@@ -11,62 +12,62 @@ HEADER = """!================================================================
 JINTRAC_CONFIG_VARS = (
     {
         'name': 'shot_in',
-        'var_type': int,
-        'var_name': 'SetUpPanel.idsIMASDBShot',
+        'type': int,
+        'key': 'SetUpPanel.idsIMASDBShot',
         'doc': 'Input IDS shot'
     },
     {
         'name': 'shot_out',
-        'var_type': int,
-        'var_name': 'SetUpPanel.shotNum',
+        'type': int,
+        'key': 'SetUpPanel.shotNum',
         'doc': 'Output IDS shot'
     },
     {
         'name': 'run_in',
-        'var_type': int,
-        'var_name': 'SetUpPanel.idsIMASDBRunid',
+        'type': int,
+        'key': 'SetUpPanel.idsIMASDBRunid',
         'doc': 'Input IDS run'
     },
     {
         'name': 'run_out',
-        'var_type': int,
-        'var_name': 'JobProcessingPanel.idsRunid',
+        'type': int,
+        'key': 'JobProcessingPanel.idsRunid',
         'doc': 'Output IDS run'
     },
     {
         'name': 'user_in',
-        'var_type': str,
-        'var_name': 'SetUpPanel.idsIMASDBUser',
+        'type': str,
+        'key': 'SetUpPanel.idsIMASDBUser',
         'doc': 'Input IDS user'
     },
     {
         'name': 'machine_in',
-        'var_type': str,
-        'var_name': 'SetUpPanel.idsIMASDBMachine',
+        'type': str,
+        'key': 'SetUpPanel.idsIMASDBMachine',
         'doc': 'Input IDS machine'
     },
     {
         'name': 'machine_out',
-        'var_type': str,
-        'var_name': 'SetUpPanel.machine',
+        'type': str,
+        'key': 'SetUpPanel.machine',
         'doc': 'Output IDS machine'
     },
     {
         'name': 'noprocessors',
-        'var_type': str,
-        'var_name': 'JobProcessingPanel.numProcessors',
+        'type': str,
+        'key': 'JobProcessingPanel.numProcessors',
         'doc': 'JobProcessingPanel.numProcessors'
     },
     {
         'name': 'tstart',
-        'var_type': float,
-        'var_name': 'SetUpPanel.startTime',
+        'type': float,
+        'key': 'SetUpPanel.startTime',
         'doc': 'Start time'
     },
     {
         'name': 'tend',
-        'var_type': float,
-        'var_name': 'SetUpPanel.endTime',
+        'type': float,
+        'key': 'SetUpPanel.endTime',
         'doc': 'End time'
     },
 )
@@ -179,7 +180,7 @@ def write_jset(path: PathLike, settings: Dict[str, Dict[str, str]]):
         f.writelines(lines)
 
 
-class JettoSettings():
+class JettoSettings:
 
     def __init__(self, mapping: Dict[str, Dict[str, str]]):
         self.raw_mapping = mapping
@@ -194,28 +195,28 @@ class JettoSettings():
 
     def __new__(cls, *args, **kwargs):
 
-        def setter(name: str, var_type):
+        def setter(jset_key: str, jset_type):
 
             def f(self, value):
-                self.settings[var_name] = str(value)
+                self.settings[jset_key] = str(value)
 
             return f
 
-        def getter(name: str, var_type):
+        def getter(jset_key: str, jset_type):
 
             def f(self):
-                return var_type(self.settings[var_name])
+                return jset_type(self.settings[jset_key])
 
             return f
 
         for variable in JINTRAC_CONFIG_VARS:
-            var_name = variable['var_name']
-            var_type = variable['var_type']
+            jset_key = variable['key']
+            jset_type = variable['type']
             name = variable['name']
             doc = variable['doc']
             prop = property(
-                fget=getter(var_name, var_type),
-                fset=setter(var_name, var_type),
+                fget=getter(jset_key, jset_type),
+                fset=setter(jset_key, jset_type),
                 doc=doc,
             )
             setattr(cls, name, prop)
@@ -233,3 +234,21 @@ class JettoSettings():
         if self.settings['SetUpPanel.selReadIds']:
             components.append('IDSIN')
         return components
+
+    @classmethod
+    def from_file(cls, path: PathLike) -> JettoSettings:
+        """Read JettoSettings from 'jetto.jset' file.
+
+        Parameters
+        ----------
+        path : PathLike
+            Path to `jetto.jset`
+
+        Returns
+        -------
+        jset : JettoSettings
+            Instance of `JettoSettings`
+        """
+        mapping = read_jset(path)
+        jset = cls(mapping)
+        return jset

--- a/duqtools/jetto/_jset.py
+++ b/duqtools/jetto/_jset.py
@@ -8,6 +8,69 @@ HEADER = """!================================================================
 !                      JETTO SETTINGS FILE
 !================================================================"""
 
+JINTRAC_CONFIG_VARS = (
+    {
+        'name': 'shot_in',
+        'var_type': int,
+        'var_name': 'SetUpPanel.idsIMASDBShot',
+        'doc': 'Input IDS shot'
+    },
+    {
+        'name': 'shot_out',
+        'var_type': int,
+        'var_name': 'SetUpPanel.shotNum',
+        'doc': 'Output IDS shot'
+    },
+    {
+        'name': 'run_in',
+        'var_type': int,
+        'var_name': 'SetUpPanel.idsIMASDBRunid',
+        'doc': 'Input IDS run'
+    },
+    {
+        'name': 'run_out',
+        'var_type': int,
+        'var_name': 'JobProcessingPanel.idsRunid',
+        'doc': 'Output IDS run'
+    },
+    {
+        'name': 'user_in',
+        'var_type': str,
+        'var_name': 'SetUpPanel.idsIMASDBUser',
+        'doc': 'Input IDS user'
+    },
+    {
+        'name': 'machine_in',
+        'var_type': str,
+        'var_name': 'SetUpPanel.idsIMASDBMachine',
+        'doc': 'Input IDS machine'
+    },
+    {
+        'name': 'machine_out',
+        'var_type': str,
+        'var_name': 'SetUpPanel.machine',
+        'doc': 'Output IDS machine'
+    },
+    {
+        'name': 'noprocessors',
+        'var_type': str,
+        'var_name': 'JobProcessingPanel.numProcessors',
+        'doc': 'JobProcessingPanel.numProcessors'
+    },
+    {
+        'name': 'tstart',
+        'var_type': float,
+        'var_name': 'SetUpPanel.startTime',
+        'doc': 'Start time'
+    },
+    {
+        'name': 'tend',
+        'var_type': float,
+        'var_name': 'SetUpPanel.endTime',
+        'doc': 'End time'
+    },
+)
+
 
 def parse_section(section: List[str]) -> Tuple[str, Dict[str, str]]:
     """Parse section of settings file.
@@ -129,8 +192,39 @@ class JettoSettings():
     def settings(self):
         return self.raw_mapping['Settings']
 
+    def __new__(cls, *args, **kwargs):
+
+        def setter(name: str, var_type):
+
+            def f(self, value):
+                self.settings[var_name] = str(value)
+
+            return f
+
+        def getter(name: str, var_type):
+
+            def f(self):
+                return var_type(self.settings[var_name])
+
+            return f
+
+        for variable in JINTRAC_CONFIG_VARS:
+            var_name = variable['var_name']
+            var_type = variable['var_type']
+            name = variable['name']
+            doc = variable['doc']
+            prop = property(
+                fget=getter(var_name, var_type),
+                fset=setter(var_name, var_type),
+                doc=doc,
+            )
+            setattr(cls, name, prop)
+
+        return super().__new__(cls)
+
     @property
     def components(self):
+        """Active components e.g. EDGE2D, JETTO, HCD (uppercase)"""
         components = ['JETTO']
         if self.settings['JobProcessingPanel.selIdsRunid']:
             components.append('IDSOUT')
@@ -139,83 +233,3 @@ class JettoSettings():
         if self.settings['SetUpPanel.selReadIds']:
             components.append('IDSIN')
         return components
-
-    @property
-    def shot_in(self):
-        return int(self.settings['SetUpPanel.idsIMASDBShot'])
-
-    @shot_in.setter
-    def shot_in(self, value: int):
-        self.settings['SetUpPanel.idsIMASDBShot'] = str(value)
-
-    @property
-    def shot_out(self):
-        return int(self.settings['SetUpPanel.shotNum'])
-
-    @shot_out.setter
-    def shot_out(self, value: int):
-        self.settings['SetUpPanel.shotNum'] = str(value)
-
-    @property
-    def run_in(self):
-        return int(self.settings['SetUpPanel.idsIMASDBRunid'])
-
-    @run_in.setter
-    def run_in(self, value: int):
-        self.settings['SetUpPanel.idsIMASDBRunid'] = str(value)
-
-    @property
-    def run_out(self):
-        return int(self.settings['JobProcessingPanel.idsRunid'])
-
-    @run_out.setter
-    def run_out(self, value: int):
-        self.settings['JobProcessingPanel.idsRunid'] = str(value)
-
-    @property
-    def user_in(self):
-        return self.settings['SetUpPanel.idsIMASDBUser']
-
-    @user_in.setter
-    def user_in(self, value: str):
-        self.settings['SetUpPanel.idsIMASDBUser'] = value
-
-    @property
-    def machine_in(self):
-        return self.settings['SetUpPanel.idsIMASDBMachine']
-
-    @machine_in.setter
-    def machine_in(self, value: str):
-        self.settings['SetUpPanel.idsIMASDBMachine'] = value
-
-    @property
-    def machine_out(self):
-        return self.settings['SetUpPanel.machine']
-
-    @machine_out.setter
-    def machine_out(self, value: str):
-        self.settings['SetUpPanel.machine'] = value
-
-    @property
-    def noprocessors(self):
-        return int(self.settings['JobProcessingPanel.numProcessors'])
-
-    @noprocessors.setter
-    def noprocessors(self, value: str):
-        self.settings['JobProcessingPanel.numProcessors'] = str(value)
-
-    @property
-    def tstart(self):
-        return float(self.settings['SetUpPanel.startTime'])
-
-    @tstart.setter
-    def tstart(self, value: float):
-        self.settings['SetUpPanel.startTime'] = str(value)
-
-    @property
-    def tend(self):
-        return float(self.settings['SetUpPanel.endTime'])
-
-    @tend.setter
-    def tend(self, value: float):
-        self.settings['SetUpPanel.endTime'] = str(value)

--- a/duqtools/jetto/_jset.py
+++ b/duqtools/jetto/_jset.py
@@ -114,3 +114,108 @@ def write_jset(path: PathLike, settings: Dict[str, Dict[str, str]]):
 
     with open(path, 'w') as f:
         f.writelines(lines)
+
+
+class JettoSettings():
+
+    def __init__(self, mapping: Dict[str, Dict[str, str]]):
+        self.raw_mapping = mapping
+
+    @property
+    def metadata(self):
+        return self.raw_mapping['File Details']
+
+    @property
+    def settings(self):
+        return self.raw_mapping['Settings']
+
+    @property
+    def components(self):
+        components = ['JETTO']
+        if self.settings['JobProcessingPanel.selIdsRunid']:
+            components.append('IDSOUT')
+        if self.settings['ExternalWFPanel.select']:
+            components.append('HCD')
+        if self.settings['SetUpPanel.selReadIds']:
+            components.append('IDSIN')
+        return components
+
+    @property
+    def shot_in(self):
+        return int(self.settings['SetUpPanel.idsIMASDBShot'])
+
+    @shot_in.setter
+    def shot_in(self, value: int):
+        self.settings['SetUpPanel.idsIMASDBShot'] = str(value)
+
+    @property
+    def shot_out(self):
+        return int(self.settings['SetUpPanel.shotNum'])
+
+    @shot_out.setter
+    def shot_out(self, value: int):
+        self.settings['SetUpPanel.shotNum'] = str(value)
+
+    @property
+    def run_in(self):
+        return int(self.settings['SetUpPanel.idsIMASDBRunid'])
+
+    @run_in.setter
+    def run_in(self, value: int):
+        self.settings['SetUpPanel.idsIMASDBRunid'] = str(value)
+
+    @property
+    def run_out(self):
+        return int(self.settings['JobProcessingPanel.idsRunid'])
+
+    @run_out.setter
+    def run_out(self, value: int):
+        self.settings['JobProcessingPanel.idsRunid'] = str(value)
+
+    @property
+    def user_in(self):
+        return self.settings['SetUpPanel.idsIMASDBUser']
+
+    @user_in.setter
+    def user_in(self, value: str):
+        self.settings['SetUpPanel.idsIMASDBUser'] = value
+
+    @property
+    def machine_in(self):
+        return self.settings['SetUpPanel.idsIMASDBMachine']
+
+    @machine_in.setter
+    def machine_in(self, value: str):
+        self.settings['SetUpPanel.idsIMASDBMachine'] = value
+
+    @property
+    def machine_out(self):
+        return self.settings['SetUpPanel.machine']
+
+    @machine_out.setter
+    def machine_out(self, value: str):
+        self.settings['SetUpPanel.machine'] = value
+
+    @property
+    def noprocessors(self):
+        return int(self.settings['JobProcessingPanel.numProcessors'])
+
+    @noprocessors.setter
+    def noprocessors(self, value: str):
+        self.settings['JobProcessingPanel.numProcessors'] = str(value)
+
+    @property
+    def tstart(self):
+        return float(self.settings['SetUpPanel.startTime'])
+
+    @tstart.setter
+    def tstart(self, value: float):
+        self.settings['SetUpPanel.startTime'] = str(value)
+
+    @property
+    def tend(self):
+        return float(self.settings['SetUpPanel.endTime'])
+
+    @tend.setter
+    def tend(self, value: float):
+        self.settings['SetUpPanel.endTime'] = str(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ include_package_data = True
 packages = find:
 install_requires =
     f90nml
-    imas
     numpy
     pydantic
     pyyaml
@@ -64,6 +63,8 @@ develop =
 publishing =
     twine
     wheel
+imas =
+    imas
 
 [options.packages.find]
 include = duqtools, duqtools.*

--- a/tests/jetto/test_jset.py
+++ b/tests/jetto/test_jset.py
@@ -1,4 +1,6 @@
-from duqtools.jetto import read_jset, write_jset
+from pathlib import Path
+
+from duqtools.jetto import JettoSettings, read_jset, write_jset
 
 JSET = {
     'section 1': {
@@ -21,3 +23,31 @@ def test_jset_io(tmp_path):
     jset2 = read_jset(path)
 
     assert JSET == jset2
+
+
+def test_JettoSettings(tmp_path):
+    fn = Path(__file__).parent / 'trimmed_jetto.jset'
+    jset = JettoSettings.from_file(fn)
+
+    from duqtools.jetto._jset import JINTRAC_CONFIG_VARS
+
+    assert isinstance(jset.metadata, dict)
+    assert isinstance(jset.settings, dict)
+
+    test_values = {
+        int: 123,
+        float: 3.14,
+        str: 'quack',
+    }
+
+    for var in JINTRAC_CONFIG_VARS:
+        var_type = var['type']
+        var_name = var['name']
+        var_key = var['key']
+        value = getattr(jset, var_name)
+        assert isinstance(value, var_type)
+
+        test_value = test_values[var_type]
+        setattr(jset, var_name, test_value)
+
+        assert jset.settings[var_key] == str(test_value)

--- a/tests/jetto/trimmed_jetto.jset
+++ b/tests/jetto/trimmed_jetto.jset
@@ -1,0 +1,46 @@
+!===============================================================================
+!                              JETTO SETTINGS FILE
+!===============================================================================
+*
+*File Details
+Creation Name                                               : /pfs/work/g2ssmee/jetto/runs/runtrial_interpretive/jetto.jset
+Creation Date                                               : 12/05/2022
+Creation Time                                               : 14:52:26
+Version                                                     : v210921_gateway_imas
+*
+*Settings
+JobProcessingPanel.driver                                   : IMAS(Python), native + IDS I/O
+JobProcessingPanel.emailNotify                              :
+JobProcessingPanel.idsRunid                                 : 251
+JobProcessingPanel.jobType                                  : Set Up Job But Don't Run
+JobProcessingPanel.loadModuleType                           : 64-bit
+JobProcessingPanel.machine                                  : jac
+JobProcessingPanel.machineNumber                            : gw
+JobProcessingPanel.name                                     : v210921_gateway_imas
+JobProcessingPanel.numProcessors                            : 2
+JobProcessingPanel.priority                                 : prio1
+JobProcessingPanel.queueName                                : gen9_ib-short
+JobProcessingPanel.runDirNumber                             : trial_interpretive
+JobProcessingPanel.selEmailNotify                           : false
+JobProcessingPanel.selIdsRunid                              : true
+JobProcessingPanel.selQueueName                             : true
+JobProcessingPanel.userid                                   : g2fkoech
+JobProcessingPanel.wallTime                                 : 24
+JobProcessingPanel.walltime                                 :
+SetUpPanel.endTime                                          : 49.0
+SetUpPanel.idsIMASDBMachine                                 : jet
+SetUpPanel.idsIMASDBRunid                                   : 2
+SetUpPanel.idsIMASDBShot                                    : 94875
+SetUpPanel.idsIMASDBUser                                    : g2aho
+SetUpPanel.idsSliceUpdateDt                                 : 1.0
+SetUpPanel.machine                                          : jet
+SetUpPanel.maxTimeStep                                      : 0.001
+SetUpPanel.maxTimeStep.ConstValue                           : 0.001
+SetUpPanel.maxTimeStep.option                               : Constant Value
+SetUpPanel.minTimeStep                                      : 1e-12
+SetUpPanel.numOfGridPoints                                  : 101
+SetUpPanel.selReadIds                                       : true
+SetUpPanel.shotNum                                          : 94875
+SetUpPanel.startTime                                        : 48.35
+*
+*EOF


### PR DESCRIPTION
This PR adds a wrapper for the Jetto settings and exposes variables that end up in `jintrac_imas_config.cfg`.

Closes #33 

## Todo:
- [x] Docstrings
- [x] Add tests for wrapper class
- [x] Refactor code