### PR TITLE
Added commandline tests, pointed workspace in example config to exampe/workspace folder

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,4 +45,4 @@ jobs:
           python -m pip install -e .[develop]
 
       - name: Test with pytest
-        run: python -m pytest --disable-warnings
+        run: python -m pytest --cov-config setup.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,4 @@ dmypy.json
 .pyre/
 
 # duqtools specific
-example/run_*
+example/workspace/

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,4 +1,4 @@
-workspace: .
+workspace: ./workspace
 create:
   template: template_model
   matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ develop =
     nbmake
     pytest
     pytest-cov
+    pytest-dependency
     pycodestyle
     # documentation
     mkdocs

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+
+import pytest
+
+
+@pytest.mark.dependency()
+def test_example_create():
+    print(os.getcwd())
+    os.chdir('./example')
+    result = subprocess.run(['duqtools', 'create', 'config.yaml'])
+    assert (result.returncode == 0)
+    os.chdir('../')
+
+
+@pytest.mark.dependency(depends=['test_example_create'])
+def test_example_status():
+    os.chdir('./example')
+    result = subprocess.run(['duqtools', 'status', 'config.yaml'])
+    assert (result.returncode == 0)
+    os.chdir('../')

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,21 +1,32 @@
 import os
+import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
+from duqtools.utils import work_directory
+
+
+@pytest.fixture(scope='session')
+def cmdline_workdir(tmp_path_factory):
+    workdir = tmp_path_factory.mktemp('test_cmdline')
+    (workdir / Path('workspace')).mkdir()
+    shutil.copy(os.getcwd() + '/example/config.yaml', workdir)
+    shutil.copytree(os.getcwd() + '/example/template_model',
+                    workdir / Path('template_model'))
+    return workdir
+
 
 @pytest.mark.dependency()
-def test_example_create():
-    print(os.getcwd())
-    os.chdir('./example')
-    result = subprocess.run(['duqtools', 'create', 'config.yaml'])
-    assert (result.returncode == 0)
-    os.chdir('../')
+def test_example_create(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        result = subprocess.run(['duqtools', 'create', 'config.yaml'])
+        assert (result.returncode == 0)
 
 
 @pytest.mark.dependency(depends=['test_example_create'])
-def test_example_status():
-    os.chdir('./example')
-    result = subprocess.run(['duqtools', 'status', 'config.yaml'])
-    assert (result.returncode == 0)
-    os.chdir('../')
+def test_example_status(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        result = subprocess.run(['duqtools', 'status', 'config.yaml'])
+        assert (result.returncode == 0)


### PR DESCRIPTION
@stefsmeets Would you agree to call the example from the tests like this? or should we execute it in a temporary folder?