### PR TITLE
Move pytest --cov-config option to config file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,4 +45,4 @@ jobs:
           python -m pip install -e .[develop]
 
       - name: Test with pytest
-        run: python -m pytest --cov-config setup.cfg
+        run: python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ source = duqtools
 
 [tool:pytest]
 testpaths = tests
-addopts = --cov --cov-report xml --cov-report term --cov-report html
+addopts = --cov --cov-report xml --cov-report term --cov-report html --cov-config setup.cfg
 norecursedirs=tests/helpers
 
 # Define `python setup.py build_sphinx`


### PR DESCRIPTION
This PR moves the --cov-config option to `setup.cfg`, so that I don't have to remember to type it 🚀