### PR TITLE
Fix broken config for the create subcommand

### DIFF
--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -1,9 +1,9 @@
-from enum import Enum
 from logging import debug
 from typing import List, Optional
 
 import yaml
 from pydantic import BaseModel, DirectoryPath
+from typing_extensions import Literal
 
 
 class Status_config(BaseModel):
@@ -24,14 +24,8 @@ class Submit_config(BaseModel):
     status_file: str = 'jetto.status'
 
 
-class Sources(Enum):
-    jetto_in = 'jetto.in'
-    jetto_jset = 'jetto.jset'
-    ids = 'ids'
-
-
 class Variable(BaseModel):
-    source: Sources
+    source: Literal['jetto.in', 'jetto.jset', 'ids']
     key: str
     values: list
 
@@ -71,6 +65,5 @@ class Config(BaseModel):
     def __new__(cls, *args, **kwargs):
         # Make it a singleton
         if not Config._instance:
-            print('XXX')
             Config._instance = object.__new__(cls)
         return Config._instance

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -1,40 +1,12 @@
 import itertools
 import shutil
-from enum import Enum
 from logging import debug
 from pathlib import Path
-from typing import List
-
-from pydantic import BaseModel, DirectoryPath
 
 from duqtools.config import Config as cfg
 
 from .ids import write_ids
 from .jetto import JettoSettings
-
-
-class Sources(Enum):
-    jetto_in = 'jetto.in'
-    jetto_jset = 'jetto.jset'
-    ids = 'ids'
-
-
-class Variable(BaseModel):
-    source: Sources
-    key: str
-    values: list
-
-    def expand(self):
-        return tuple({
-            'source': self.source,
-            'key': self.key,
-            'value': value
-        } for value in self.values)
-
-
-class ConfigCreate(BaseModel):
-    matrix: List[Variable] = []
-    template: DirectoryPath
 
 
 def copy_files(source_drc: Path, target_drc: Path):
@@ -101,14 +73,14 @@ def create(**kwargs):
 
         patch = {
             d['key']: d['value']
-            for d in combination if d['source'] == Sources.jetto_jset
+            for d in combination if d['source'] == 'jetto.jset'
         }
         jset_patched = jset.copy_and_patch(settings=patch)
         jset_patched.to_directory(target_drc)
 
         ids_data = {
             d['key']: d['value']
-            for d in combination if d['source'] == Sources.ids
+            for d in combination if d['source'] == 'ids'
         }
 
         write_ids(target_drc / 'ids.yaml', ids_data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     numpy
     pydantic
     pyyaml
+    typing-extensions
 
 [options.data_files]
 # This section requires setuptools>=40.6.0


### PR DESCRIPTION
The config for the `create` subcommand was created in two places. The `Enum` was being defined in two places, which caused the workflow to break. I replaced the `Enum` with a `Literal` type (backport from 3.8 from the `typing_extensions` module) and removed the duplicated config class.