### PR TITLE
Implement Latin Hypercube sampler

### DIFF
--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -70,6 +70,15 @@ class LHSSampler(BaseModel):
         return latin_hypercube(*args, n_samples=self.n_samples)
 
 
+class SobolSampler(BaseModel):
+    method: Literal['sobol', 'low-discrepancy-sequence']
+    n_samples: int
+
+    def __call__(self, *args):
+        from duqtools.samplers import sobol
+        return sobol(*args, n_samples=self.n_samples)
+
+
 class CartesianProduct(BaseModel):
     method: Literal['cartesian-product'] = 'cartesian-product'
 
@@ -80,7 +89,7 @@ class CartesianProduct(BaseModel):
 
 class ConfigCreate(BaseModel):
     matrix: List[IDSOperation] = []
-    sampler: Union[LHSSampler,
+    sampler: Union[LHSSampler, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
                                              discriminator='method')
     template: DirectoryPath

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -70,6 +70,15 @@ class LHSSampler(BaseModel):
         return latin_hypercube(*args, n_samples=self.n_samples)
 
 
+class Halton(BaseModel):
+    method: Literal['halton']
+    n_samples: int
+
+    def __call__(self, *args):
+        from duqtools.samplers import halton
+        return halton(*args, n_samples=self.n_samples)
+
+
 class SobolSampler(BaseModel):
     method: Literal['sobol', 'low-discrepancy-sequence']
     n_samples: int
@@ -89,7 +98,7 @@ class CartesianProduct(BaseModel):
 
 class ConfigCreate(BaseModel):
     matrix: List[IDSOperation] = []
-    sampler: Union[LHSSampler, SobolSampler,
+    sampler: Union[LHSSampler, Halton, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
                                              discriminator='method')
     template: DirectoryPath

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import shutil
 from pathlib import Path
@@ -66,8 +65,6 @@ def apply(operation: dict, core_profiles) -> None:
     """
     ids = operation['ids']
     operator = operation['operator']
-    assert operator in ('add', 'multiply', 'divide', 'power', 'subtract',
-                        'floor_divide', 'mod', 'remainder')
 
     value = operation['value']
 
@@ -93,15 +90,15 @@ def create(**kwargs):
 
     template_drc = options.template
     matrix = options.matrix
-
-    expanded_vars = tuple(var.expand() for var in matrix)
-
-    combinations = itertools.product(*expanded_vars)
+    sampler = options.sampler
 
     jset = JettoSettings.from_directory(template_drc)
 
     source = ImasLocation.from_jset_input(jset)
     assert source.path().exists()
+
+    variables = tuple(var.expand() for var in matrix)
+    combinations = sampler(*variables)
 
     for i, combination in enumerate(combinations):
         sub_drc = f'run_{i:04d}'

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -1,33 +1,55 @@
+import itertools
+
 import numpy as np
 from scipy.stats import qmc
 
 
-def latin_hypercube(*args, n_samples: int):
-    """Sample from *args using Latin hypercube sampling (LHS).
+def cartesian_product(*iterables):
+    """Return cartesian product of input iterables.
 
-    Uses `scip.stats.qmc.LatinHyperCube`.
+    Uses `itertools.product`
 
     Parameters
     ----------
-    *args
-        Sequences to sample from.
+    *iterables
+        Input iterables.
+
+    Returns
+    -------
+    list[Any]
+        List of product of input arguments.
+    """
+    return list(itertools.product(*iterables))
+
+
+def latin_hypercube(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using Latin hypercube sampling (LHS).
+
+    Uses `scipy.stats.qmc.LatinHyperCube`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
     n_samples : int
         Number of samples to return.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.LatinHypercube`
 
     Returns
     -------
     samples : list[Any]
         List of sampled input arguments.
     """
-    bounds = tuple(len(seq) for seq in args)
+    bounds = tuple(len(iterable) for iterable in iterables)
 
-    sampler = qmc.LatinHypercube(d=len(args))
+    sampler = qmc.LatinHypercube(d=len(iterables), **kwargs)
     unit_samples = sampler.random(n_samples)
 
     indices = np.floor(unit_samples * np.array(bounds)).astype(int)
 
     samples = []
     for row in indices:
-        samples.append(tuple(arg[col] for col, arg in zip(row, args)))
+        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
 
     return samples

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -22,6 +22,22 @@ def cartesian_product(*iterables):
     return list(itertools.product(*iterables))
 
 
+def _sampler(func, *iterables, n_samples: int, **kwargs):
+    """Generic sampler."""
+    bounds = tuple(len(iterable) for iterable in iterables)
+
+    sampler = func(d=len(iterables), **kwargs)
+    unit_samples = sampler.random(n_samples)
+
+    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
+
+    samples = []
+    for row in indices:
+        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
+
+    return samples
+
+
 def latin_hypercube(*iterables, n_samples: int, **kwargs):
     """Sample input iterables using Latin hypercube sampling (LHS).
 
@@ -41,9 +57,37 @@ def latin_hypercube(*iterables, n_samples: int, **kwargs):
     samples : list[Any]
         List of sampled input arguments.
     """
+    return _sampler(qmc.LatinHypercube,
+                    *iterables,
+                    n_samples=n_samples,
+                    **kwargs)
+
+
+def sobol(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using the Sobol sampling method for generating
+    low discrepancy sequences.
+
+    Uses `scipy.stats.qmc.Sobol`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
+    n_samples : int
+        Number of samples to return. Note that Sobol sequences lose their
+        balance  properties if one uses a sample size that is not a power
+        of two.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.Sobol`
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
     bounds = tuple(len(iterable) for iterable in iterables)
 
-    sampler = qmc.LatinHypercube(d=len(iterables), **kwargs)
+    sampler = qmc.Sobol(d=len(iterables), **kwargs)
     unit_samples = sampler.random(n_samples)
 
     indices = np.floor(unit_samples * np.array(bounds)).astype(int)

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -86,3 +86,25 @@ def sobol(*iterables, n_samples: int, **kwargs):
         List of sampled input arguments.
     """
     return _sampler(qmc.Sobol, *iterables, n_samples=n_samples, **kwargs)
+
+
+def halton(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using the Halton sampling method.
+
+    Uses `scipy.stats.qmc.Halton`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
+    n_samples : int
+        Number of samples to return.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.Halton`
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
+    return _sampler(qmc.Halton, *iterables, n_samples=n_samples, **kwargs)

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -1,0 +1,33 @@
+import numpy as np
+from scipy.stats import qmc
+
+
+def latin_hypercube(*args, n_samples: int):
+    """Sample from *args using Latin hypercube sampling (LHS).
+
+    Uses `scip.stats.qmc.LatinHyperCube`.
+
+    Parameters
+    ----------
+    *args
+        Sequences to sample from.
+    n_samples : int
+        Number of samples to return.
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
+    bounds = tuple(len(seq) for seq in args)
+
+    sampler = qmc.LatinHypercube(d=len(args))
+    unit_samples = sampler.random(n_samples)
+
+    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
+
+    samples = []
+    for row in indices:
+        samples.append(tuple(arg[col] for col, arg in zip(row, args)))
+
+    return samples

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -85,15 +85,4 @@ def sobol(*iterables, n_samples: int, **kwargs):
     samples : list[Any]
         List of sampled input arguments.
     """
-    bounds = tuple(len(iterable) for iterable in iterables)
-
-    sampler = qmc.Sobol(d=len(iterables), **kwargs)
-    unit_samples = sampler.random(n_samples)
-
-    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
-
-    samples = []
-    for row in indices:
-        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
-
-    return samples
+    return _sampler(qmc.Sobol, *iterables, n_samples=n_samples, **kwargs)

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -5,6 +5,9 @@ create:
     db: jet
     run_in_start_at: 7000
     run_out_start_at: 8000
+  sampler:
+    method: latin-hypercube
+    n_samples: 3
   matrix:
     - ids: zeff
       operator: add

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     numpy
     pydantic
     pyyaml
+    scipy
     typing-extensions
 
 [options.data_files]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,4 +1,4 @@
-from duqtools.samplers import cartesian_product, latin_hypercube
+from duqtools.samplers import cartesian_product, latin_hypercube, sobol
 
 
 def test_cartesian_product():
@@ -19,3 +19,14 @@ def test_latin_hypercube():
     ret = latin_hypercube(i, j, k, n_samples=3, seed=123)
 
     assert ret == [('b', 'e', 'h'), ('b', 'd', 'h'), ('a', 'c', 'f')]
+
+
+def test_sobol():
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
+
+    ret = sobol(i, j, k, n_samples=4, seed=123)
+
+    assert ret == [('b', 'd', 'g'), ('a', 'c', 'i'), ('a', 'e', 'f'),
+                   ('b', 'c', 'h')]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,0 +1,9 @@
+from duqtools.samplers import latin_hypercube
+
+
+def test_latin_hypercube():
+    i = list('ab')
+    j = list('cde')
+    k = list('fghi')
+
+    latin_hypercube(i, j, k, n_samples=5)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,4 +1,4 @@
-from duqtools.samplers import cartesian_product, latin_hypercube, sobol
+from duqtools.samplers import cartesian_product, halton, latin_hypercube, sobol
 
 
 def test_cartesian_product():
@@ -29,4 +29,15 @@ def test_sobol():
     ret = sobol(i, j, k, n_samples=4, seed=123)
 
     assert ret == [('b', 'd', 'g'), ('a', 'c', 'i'), ('a', 'e', 'f'),
+                   ('b', 'c', 'h')]
+
+
+def test_halton():
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
+
+    ret = halton(i, j, k, n_samples=4, seed=123)
+
+    assert ret == [('a', 'c', 'i'), ('b', 'e', 'f'), ('a', 'd', 'h'),
                    ('b', 'c', 'h')]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,9 +1,21 @@
-from duqtools.samplers import latin_hypercube
+from duqtools.samplers import cartesian_product, latin_hypercube
+
+
+def test_cartesian_product():
+    i = 'ab'
+    j = 'def'
+
+    ret = cartesian_product(i, j)
+
+    assert ret == [('a', 'd'), ('a', 'e'), ('a', 'f'), ('b', 'd'), ('b', 'e'),
+                   ('b', 'f')]
 
 
 def test_latin_hypercube():
-    i = list('ab')
-    j = list('cde')
-    k = list('fghi')
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
 
-    latin_hypercube(i, j, k, n_samples=5)
+    ret = latin_hypercube(i, j, k, n_samples=3, seed=123)
+
+    assert ret == [('b', 'e', 'h'), ('b', 'd', 'h'), ('a', 'c', 'f')]


### PR DESCRIPTION
This PR adds a new module with samplers. For the moment it contains the Latin Hypercube.

Addresses #58 

## Todo
- [x] Add option to `create` config
- [x] Implement sampling on `create` subcommand