### PR TITLE
Initialize config as a module attribute

### DIFF
--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -70,6 +70,15 @@ class LHSSampler(BaseModel):
         return latin_hypercube(*args, n_samples=self.n_samples)
 
 
+class SobolSampler(BaseModel):
+    method: Literal['sobol', 'low-discrepancy-sequence']
+    n_samples: int
+
+    def __call__(self, *args):
+        from duqtools.samplers import sobol
+        return sobol(*args, n_samples=self.n_samples)
+
+
 class CartesianProduct(BaseModel):
     method: Literal['cartesian-product'] = 'cartesian-product'
 
@@ -80,7 +89,7 @@ class CartesianProduct(BaseModel):
 
 class ConfigCreate(BaseModel):
     matrix: List[IDSOperation] = []
-    sampler: Union[LHSSampler,
+    sampler: Union[LHSSampler, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
                                              discriminator='method')
     template: DirectoryPath

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -70,6 +70,15 @@ class LHSSampler(BaseModel):
         return latin_hypercube(*args, n_samples=self.n_samples)
 
 
+class Halton(BaseModel):
+    method: Literal['halton']
+    n_samples: int
+
+    def __call__(self, *args):
+        from duqtools.samplers import halton
+        return halton(*args, n_samples=self.n_samples)
+
+
 class SobolSampler(BaseModel):
     method: Literal['sobol', 'low-discrepancy-sequence']
     n_samples: int
@@ -89,7 +98,7 @@ class CartesianProduct(BaseModel):
 
 class ConfigCreate(BaseModel):
     matrix: List[IDSOperation] = []
-    sampler: Union[LHSSampler, SobolSampler,
+    sampler: Union[LHSSampler, Halton, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
                                              discriminator='method')
     template: DirectoryPath

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 logger = logging.getLogger(__name__)
 
 
-class Status_config(BaseModel):
+class StatusConfig(BaseModel):
     """Status_config."""
 
     msg_completed: str = 'Status : Completed successfully'
@@ -18,7 +18,7 @@ class Status_config(BaseModel):
     msg_running: str = 'Status : Running'
 
 
-class Submit_config(BaseModel):
+class SubmitConfig(BaseModel):
     """Submit_config.
 
     Config class for submitting jobs
@@ -96,7 +96,7 @@ class CartesianProduct(BaseModel):
         return cartesian_product(*args)
 
 
-class ConfigCreate(BaseModel):
+class CreateConfig(BaseModel):
     matrix: List[IDSOperation] = []
     sampler: Union[LHSSampler, Halton, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
@@ -112,9 +112,9 @@ class Config(BaseModel):
     _instance = None
 
     # pydantic members
-    submit: Submit_config = Submit_config()
-    create: Optional[ConfigCreate]
-    status: Status_config = Status_config()
+    submit: SubmitConfig = SubmitConfig()
+    create: Optional[CreateConfig]
+    status: StatusConfig = StatusConfig()
     workspace: DirectoryPath = './workspace'
 
     def __init__(self, filename=None):
@@ -130,3 +130,6 @@ class Config(BaseModel):
         if not Config._instance:
             Config._instance = object.__new__(cls)
         return Config._instance
+
+
+cfg = Config()

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -1,4 +1,3 @@
-import itertools
 import logging
 import shutil
 from pathlib import Path
@@ -66,8 +65,6 @@ def apply(operation: dict, core_profiles) -> None:
     """
     ids = operation['ids']
     operator = operation['operator']
-    assert operator in ('add', 'multiply', 'divide', 'power', 'subtract',
-                        'floor_divide', 'mod', 'remainder')
 
     value = operation['value']
 
@@ -93,15 +90,15 @@ def create(**kwargs):
 
     template_drc = options.template
     matrix = options.matrix
-
-    expanded_vars = tuple(var.expand() for var in matrix)
-
-    combinations = itertools.product(*expanded_vars)
+    sampler = options.sampler
 
     jset = JettoSettings.from_directory(template_drc)
 
     source = ImasLocation.from_jset_input(jset)
     assert source.path().exists()
+
+    variables = tuple(var.expand() for var in matrix)
+    combinations = sampler(*variables)
 
     for i, combination in enumerate(combinations):
         sub_drc = f'run_{i:04d}'

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from duqtools.config import Config as cfg
+from duqtools.config import cfg
 
 from .ids import ImasLocation
 from .jetto import JettoSettings
@@ -86,7 +86,7 @@ def create(**kwargs):
     **kwargs
         Unused.
     """
-    options = cfg().create
+    options = cfg.create
 
     template_drc = options.template
     matrix = options.matrix
@@ -102,7 +102,7 @@ def create(**kwargs):
 
     for i, combination in enumerate(combinations):
         sub_drc = f'run_{i:04d}'
-        target_drc = cfg().workspace / sub_drc
+        target_drc = cfg.workspace / sub_drc
         target_drc.mkdir(parents=True, exist_ok=True)
 
         copy_files(template_drc, target_drc)

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -1,33 +1,55 @@
+import itertools
+
 import numpy as np
 from scipy.stats import qmc
 
 
-def latin_hypercube(*args, n_samples: int):
-    """Sample from *args using Latin hypercube sampling (LHS).
+def cartesian_product(*iterables):
+    """Return cartesian product of input iterables.
 
-    Uses `scip.stats.qmc.LatinHyperCube`.
+    Uses `itertools.product`
 
     Parameters
     ----------
-    *args
-        Sequences to sample from.
+    *iterables
+        Input iterables.
+
+    Returns
+    -------
+    list[Any]
+        List of product of input arguments.
+    """
+    return list(itertools.product(*iterables))
+
+
+def latin_hypercube(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using Latin hypercube sampling (LHS).
+
+    Uses `scipy.stats.qmc.LatinHyperCube`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
     n_samples : int
         Number of samples to return.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.LatinHypercube`
 
     Returns
     -------
     samples : list[Any]
         List of sampled input arguments.
     """
-    bounds = tuple(len(seq) for seq in args)
+    bounds = tuple(len(iterable) for iterable in iterables)
 
-    sampler = qmc.LatinHypercube(d=len(args))
+    sampler = qmc.LatinHypercube(d=len(iterables), **kwargs)
     unit_samples = sampler.random(n_samples)
 
     indices = np.floor(unit_samples * np.array(bounds)).astype(int)
 
     samples = []
     for row in indices:
-        samples.append(tuple(arg[col] for col, arg in zip(row, args)))
+        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
 
     return samples

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -22,6 +22,22 @@ def cartesian_product(*iterables):
     return list(itertools.product(*iterables))
 
 
+def _sampler(func, *iterables, n_samples: int, **kwargs):
+    """Generic sampler."""
+    bounds = tuple(len(iterable) for iterable in iterables)
+
+    sampler = func(d=len(iterables), **kwargs)
+    unit_samples = sampler.random(n_samples)
+
+    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
+
+    samples = []
+    for row in indices:
+        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
+
+    return samples
+
+
 def latin_hypercube(*iterables, n_samples: int, **kwargs):
     """Sample input iterables using Latin hypercube sampling (LHS).
 
@@ -41,9 +57,37 @@ def latin_hypercube(*iterables, n_samples: int, **kwargs):
     samples : list[Any]
         List of sampled input arguments.
     """
+    return _sampler(qmc.LatinHypercube,
+                    *iterables,
+                    n_samples=n_samples,
+                    **kwargs)
+
+
+def sobol(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using the Sobol sampling method for generating
+    low discrepancy sequences.
+
+    Uses `scipy.stats.qmc.Sobol`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
+    n_samples : int
+        Number of samples to return. Note that Sobol sequences lose their
+        balance  properties if one uses a sample size that is not a power
+        of two.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.Sobol`
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
     bounds = tuple(len(iterable) for iterable in iterables)
 
-    sampler = qmc.LatinHypercube(d=len(iterables), **kwargs)
+    sampler = qmc.Sobol(d=len(iterables), **kwargs)
     unit_samples = sampler.random(n_samples)
 
     indices = np.floor(unit_samples * np.array(bounds)).astype(int)

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -86,3 +86,25 @@ def sobol(*iterables, n_samples: int, **kwargs):
         List of sampled input arguments.
     """
     return _sampler(qmc.Sobol, *iterables, n_samples=n_samples, **kwargs)
+
+
+def halton(*iterables, n_samples: int, **kwargs):
+    """Sample input iterables using the Halton sampling method.
+
+    Uses `scipy.stats.qmc.Halton`.
+
+    Parameters
+    ----------
+    *iterables
+        Iterables to sample from.
+    n_samples : int
+        Number of samples to return.
+    **kwargs
+        These keyword arguments are passed to `scipy.stats.qmc.Halton`
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
+    return _sampler(qmc.Halton, *iterables, n_samples=n_samples, **kwargs)

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -1,0 +1,33 @@
+import numpy as np
+from scipy.stats import qmc
+
+
+def latin_hypercube(*args, n_samples: int):
+    """Sample from *args using Latin hypercube sampling (LHS).
+
+    Uses `scip.stats.qmc.LatinHyperCube`.
+
+    Parameters
+    ----------
+    *args
+        Sequences to sample from.
+    n_samples : int
+        Number of samples to return.
+
+    Returns
+    -------
+    samples : list[Any]
+        List of sampled input arguments.
+    """
+    bounds = tuple(len(seq) for seq in args)
+
+    sampler = qmc.LatinHypercube(d=len(args))
+    unit_samples = sampler.random(n_samples)
+
+    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
+
+    samples = []
+    for row in indices:
+        samples.append(tuple(arg[col] for col, arg in zip(row, args)))
+
+    return samples

--- a/duqtools/samplers.py
+++ b/duqtools/samplers.py
@@ -85,15 +85,4 @@ def sobol(*iterables, n_samples: int, **kwargs):
     samples : list[Any]
         List of sampled input arguments.
     """
-    bounds = tuple(len(iterable) for iterable in iterables)
-
-    sampler = qmc.Sobol(d=len(iterables), **kwargs)
-    unit_samples = sampler.random(n_samples)
-
-    indices = np.floor(unit_samples * np.array(bounds)).astype(int)
-
-    samples = []
-    for row in indices:
-        samples.append(tuple(arg[col] for col, arg in zip(row, iterables)))
-
-    return samples
+    return _sampler(qmc.Sobol, *iterables, n_samples=n_samples, **kwargs)

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -2,7 +2,7 @@ import logging
 from os import scandir
 from pathlib import Path
 
-from .config import Config as cfg
+from .config import cfg
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ def has_submit_script(dir: Path) -> bool:
     -------
     bool
     """
-    return (dir / cfg().submit.submit_script_name).exists()
+    return (dir / cfg.submit.submit_script_name).exists()
 
 
 def has_status(dir: Path) -> bool:
@@ -34,7 +34,7 @@ def has_status(dir: Path) -> bool:
     -------
     bool
     """
-    return (dir / cfg().submit.status_file).exists()
+    return (dir / cfg.submit.status_file).exists()
 
 
 def status_file_contains(dir: Path, msg) -> bool:
@@ -51,7 +51,7 @@ def status_file_contains(dir: Path, msg) -> bool:
     -------
     bool
     """
-    sf = (dir / cfg().submit.status_file)
+    sf = (dir / cfg.submit.status_file)
     with open(sf, 'r') as f:
         content = f.read()
         logger.debug('Checking if content of %s file: %s contains %s' %
@@ -71,7 +71,7 @@ def is_completed(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_completed)
+    return status_file_contains(dir, cfg.status.msg_completed)
 
 
 def is_failed(dir: Path) -> bool:
@@ -86,7 +86,7 @@ def is_failed(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_failed)
+    return status_file_contains(dir, cfg.status.msg_failed)
 
 
 def is_running(dir: Path) -> bool:
@@ -101,18 +101,16 @@ def is_running(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_running)
+    return status_file_contains(dir, cfg.status.msg_running)
 
 
 def status(**kwargs):
     """status."""
-    if not cfg().submit:
+    if not cfg.submit:
         raise Exception('submit field required in config file')
-    logger.debug('Submit config: %s' % cfg().submit)
+    logger.debug('Submit config: %s' % cfg.submit)
 
-    dirs = [
-        Path(entry) for entry in scandir(cfg().workspace) if entry.is_dir()
-    ]
+    dirs = [Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()]
     logger.debug('Case directories: %s' % dirs)
 
     logger.info('Total number of directories: %i' % len(dirs))

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -3,7 +3,7 @@ import subprocess
 from os import scandir
 from pathlib import Path
 
-from duqtools.config import Config as cfg
+from duqtools.config import cfg
 
 logger = logging.getLogger(__name__)
 
@@ -17,17 +17,17 @@ def submit(**kwargs):
 
     args = kwargs.args
 
-    if not cfg().submit:
+    if not cfg.submit:
         raise Exception('submit field required in config file')
-    logger.debug('Submit config: %s' % cfg().submit)
+    logger.debug('Submit config: %s' % cfg.submit)
 
     run_dirs = [
-        Path(entry) for entry in scandir(cfg().workspace) if entry.is_dir()
+        Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()
     ]
     logger.debug('Case directories: %s' % run_dirs)
 
     for run_dir in run_dirs:
-        submission_script = run_dir / cfg().submit.submit_script_name
+        submission_script = run_dir / cfg.submit.submit_script_name
         if submission_script.is_file():
             logger.info('Found submission script: %s ; Ready for submission' %
                         submission_script)
@@ -37,7 +37,7 @@ def submit(**kwargs):
                 submission_script)
             continue
 
-        status_file = run_dir / cfg().submit.status_file
+        status_file = run_dir / cfg.submit.status_file
         if status_file.exists() and not args.force:
             if not status_file.is_file():
                 logger.error('Status file %s is not a file' % status_file)

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -5,6 +5,9 @@ create:
     db: jet
     run_in_start_at: 7000
     run_out_start_at: 8000
+  sampler:
+    method: latin-hypercube
+    n_samples: 3
   matrix:
     - ids: zeff
       operator: add

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     numpy
     pydantic
     pyyaml
+    scipy
     typing-extensions
 
 [options.data_files]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,4 +1,4 @@
-from duqtools.samplers import cartesian_product, latin_hypercube
+from duqtools.samplers import cartesian_product, latin_hypercube, sobol
 
 
 def test_cartesian_product():
@@ -19,3 +19,14 @@ def test_latin_hypercube():
     ret = latin_hypercube(i, j, k, n_samples=3, seed=123)
 
     assert ret == [('b', 'e', 'h'), ('b', 'd', 'h'), ('a', 'c', 'f')]
+
+
+def test_sobol():
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
+
+    ret = sobol(i, j, k, n_samples=4, seed=123)
+
+    assert ret == [('b', 'd', 'g'), ('a', 'c', 'i'), ('a', 'e', 'f'),
+                   ('b', 'c', 'h')]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,0 +1,9 @@
+from duqtools.samplers import latin_hypercube
+
+
+def test_latin_hypercube():
+    i = list('ab')
+    j = list('cde')
+    k = list('fghi')
+
+    latin_hypercube(i, j, k, n_samples=5)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,4 +1,4 @@
-from duqtools.samplers import cartesian_product, latin_hypercube, sobol
+from duqtools.samplers import cartesian_product, halton, latin_hypercube, sobol
 
 
 def test_cartesian_product():
@@ -29,4 +29,15 @@ def test_sobol():
     ret = sobol(i, j, k, n_samples=4, seed=123)
 
     assert ret == [('b', 'd', 'g'), ('a', 'c', 'i'), ('a', 'e', 'f'),
+                   ('b', 'c', 'h')]
+
+
+def test_halton():
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
+
+    ret = halton(i, j, k, n_samples=4, seed=123)
+
+    assert ret == [('a', 'c', 'i'), ('b', 'e', 'f'), ('a', 'd', 'h'),
                    ('b', 'c', 'h')]

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,9 +1,21 @@
-from duqtools.samplers import latin_hypercube
+from duqtools.samplers import cartesian_product, latin_hypercube
+
+
+def test_cartesian_product():
+    i = 'ab'
+    j = 'def'
+
+    ret = cartesian_product(i, j)
+
+    assert ret == [('a', 'd'), ('a', 'e'), ('a', 'f'), ('b', 'd'), ('b', 'e'),
+                   ('b', 'f')]
 
 
 def test_latin_hypercube():
-    i = list('ab')
-    j = list('cde')
-    k = list('fghi')
+    i = 'ab'
+    j = 'cde'
+    k = 'fghi'
 
-    latin_hypercube(i, j, k, n_samples=5)
+    ret = latin_hypercube(i, j, k, n_samples=3, seed=123)
+
+    assert ret == [('b', 'e', 'h'), ('b', 'd', 'h'), ('a', 'c', 'f')]


### PR DESCRIPTION
This PR sets the config as a module attibute.

Instead of:

```python
from duqtools.config import Config as cfg
cfg().variable
```

use

```python
from duqtools.config import cfg
cfg.variable
```
