### PR TITLE
Initialize `Config()` as a module attribute

### DIFF
--- a/duqtools/__main__.py
+++ b/duqtools/__main__.py
@@ -63,7 +63,7 @@ def cmdline():
 
     # Load the config file
     if not args.func == init:  # dont read it if we have to create it
-        cfg.Config(args.CONFIG)
+        cfg.read(args.CONFIG)
 
     # Run the subcommand
     args.func(args=args)

--- a/duqtools/__main__.py
+++ b/duqtools/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-import duqtools.config as cfg
+from duqtools.config import cfg
 
 from .create import create
 from .init import init

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -9,6 +9,8 @@ from typing_extensions import Literal
 
 from duqtools.ids.ids_location import ImasLocation
 
+from ._types import PathLike
+
 logger = logging.getLogger(__name__)
 
 
@@ -152,16 +154,20 @@ class Config(BaseModel):
     def __init__(self, filename=None):
         """Initialize with optional filename argument."""
         if filename:
-            with open(filename, 'r') as f:
-                datamap = yaml.safe_load(f)
-                logger.debug(datamap)
-                BaseModel.__init__(self, **datamap)
+            self.read(filename)
 
     def __new__(cls, *args, **kwargs):
         # Make it a singleton
         if not Config._instance:
             Config._instance = object.__new__(cls)
         return Config._instance
+
+    def read(self, filename: PathLike):
+        """Read config from file."""
+        with open(filename, 'r') as f:
+            datamap = yaml.safe_load(f)
+            logger.debug(datamap)
+            BaseModel.__init__(self, **datamap)
 
 
 cfg = Config()

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -29,7 +29,7 @@ class Plot(BaseModel):
         return self.ylabel if self.ylabel else self.y
 
 
-class Plot_config(BaseModel):
+class PlotConfig(BaseModel):
     data: List[ImasLocation] = [
         ImasLocation(**{
             'db': 'jet',
@@ -41,7 +41,7 @@ class Plot_config(BaseModel):
     plots: List[Plot] = [Plot()]
 
 
-class Status_config(BaseModel):
+class StatusConfig(BaseModel):
     """Status_config."""
 
     msg_completed: str = 'Status : Completed successfully'
@@ -49,7 +49,7 @@ class Status_config(BaseModel):
     msg_running: str = 'Status : Running'
 
 
-class Submit_config(BaseModel):
+class SubmitConfig(BaseModel):
     """Submit_config.
 
     Config class for submitting jobs
@@ -127,7 +127,7 @@ class CartesianProduct(BaseModel):
         return cartesian_product(*args)
 
 
-class ConfigCreate(BaseModel):
+class CreateConfig(BaseModel):
     matrix: List[IDSOperation] = []
     sampler: Union[LHSSampler, Halton, SobolSampler,
                    CartesianProduct] = Field(default=CartesianProduct(),
@@ -143,10 +143,10 @@ class Config(BaseModel):
     _instance = None
 
     # pydantic members
-    submit: Submit_config = Submit_config()
-    create: Optional[ConfigCreate]
-    status: Status_config = Status_config()
-    plot: Plot_config = Plot_config()
+    plot: PlotConfig = PlotConfig()
+    submit: SubmitConfig = SubmitConfig()
+    create: Optional[CreateConfig]
+    status: StatusConfig = StatusConfig()
     workspace: DirectoryPath = './workspace'
 
     def __init__(self, filename=None):
@@ -162,3 +162,6 @@ class Config(BaseModel):
         if not Config._instance:
             Config._instance = object.__new__(cls)
         return Config._instance
+
+
+cfg = Config()

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from duqtools.config import Config as cfg
+from duqtools.config import cfg
 
 from .ids import ImasLocation
 from .jetto import JettoSettings
@@ -86,7 +86,7 @@ def create(**kwargs):
     **kwargs
         Unused.
     """
-    options = cfg().create
+    options = cfg.create
 
     template_drc = options.template
     matrix = options.matrix
@@ -102,7 +102,7 @@ def create(**kwargs):
 
     for i, combination in enumerate(combinations):
         sub_drc = f'run_{i:04d}'
-        target_drc = cfg().workspace / sub_drc
+        target_drc = cfg.workspace / sub_drc
         target_drc.mkdir(parents=True, exist_ok=True)
 
         copy_files(template_drc, target_drc)

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -3,7 +3,7 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 
-from .config import Config as cfg
+from .config import cfg
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -22,11 +22,11 @@ def plot(**kwargs):
     # Gather all results and put them in a in-memory format
     # (they should be small enough)
     profiles = []
-    for entry in cfg().plot.data:
+    for entry in cfg.plot.data:
         debug('Extracting database: %s' % entry)
         profiles.append(entry.get_simple_IDS('core_profiles'))
 
-    for i, plot in enumerate(cfg().plot.plots):
+    for i, plot in enumerate(cfg.plot.plots):
         info('Creating plot number %04i' % i)
         for profile in profiles:
             y = profile.flat_fields[plot.y]

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -2,7 +2,7 @@ import logging
 from os import scandir
 from pathlib import Path
 
-from .config import Config as cfg
+from .config import cfg
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -20,7 +20,7 @@ def has_submit_script(dir: Path) -> bool:
     -------
     bool
     """
-    return (dir / cfg().submit.submit_script_name).exists()
+    return (dir / cfg.submit.submit_script_name).exists()
 
 
 def has_status(dir: Path) -> bool:
@@ -35,7 +35,7 @@ def has_status(dir: Path) -> bool:
     -------
     bool
     """
-    return (dir / cfg().submit.status_file).exists()
+    return (dir / cfg.submit.status_file).exists()
 
 
 def status_file_contains(dir: Path, msg) -> bool:
@@ -52,7 +52,7 @@ def status_file_contains(dir: Path, msg) -> bool:
     -------
     bool
     """
-    sf = (dir / cfg().submit.status_file)
+    sf = (dir / cfg.submit.status_file)
     with open(sf, 'r') as f:
         content = f.read()
         debug('Checking if content of %s file: %s contains %s' %
@@ -72,7 +72,7 @@ def is_completed(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_completed)
+    return status_file_contains(dir, cfg.status.msg_completed)
 
 
 def is_failed(dir: Path) -> bool:
@@ -87,7 +87,7 @@ def is_failed(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_failed)
+    return status_file_contains(dir, cfg.status.msg_failed)
 
 
 def is_running(dir: Path) -> bool:
@@ -102,18 +102,17 @@ def is_running(dir: Path) -> bool:
     -------
     bool
     """
-    return status_file_contains(dir, cfg().status.msg_running)
+    return status_file_contains(dir, cfg.status.msg_running)
 
 
 def status(**kwargs):
     """status."""
-    if not cfg().submit:
+    if not cfg.submit:
         raise Exception('submit field required in config file')
+
     debug('Submit config: %s' % cfg().submit)
 
-    dirs = [
-        Path(entry) for entry in scandir(cfg().workspace) if entry.is_dir()
-    ]
+    dirs = [Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()]
     debug('Case directories: %s' % dirs)
 
     info('Total number of directories: %i' % len(dirs))

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -110,7 +110,7 @@ def status(**kwargs):
     if not cfg.submit:
         raise Exception('submit field required in config file')
 
-    debug('Submit config: %s' % cfg().submit)
+    debug('Submit config: %s' % cfg.submit)
 
     dirs = [Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()]
     debug('Case directories: %s' % dirs)

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -3,7 +3,7 @@ import subprocess
 from os import scandir
 from pathlib import Path
 
-from duqtools.config import Config as cfg
+from duqtools.config import cfg
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -18,17 +18,18 @@ def submit(**kwargs):
 
     args = kwargs['args']
 
-    if not cfg().submit:
+    if not cfg.submit:
         raise Exception('submit field required in config file')
-    debug('Submit config: %s' % cfg().submit)
+
+    debug('Submit config: %s' % cfg.submit)
 
     run_dirs = [
-        Path(entry) for entry in scandir(cfg().workspace) if entry.is_dir()
+        Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()
     ]
     debug('Case directories: %s' % run_dirs)
 
     for run_dir in run_dirs:
-        submission_script = run_dir / cfg().submit.submit_script_name
+        submission_script = run_dir / cfg.submit.submit_script_name
         if submission_script.is_file():
             info('Found submission script: %s ; Ready for submission' %
                  submission_script)
@@ -38,7 +39,7 @@ def submit(**kwargs):
                 submission_script)
             continue
 
-        status_file = run_dir / cfg().submit.status_file
+        status_file = run_dir / cfg.submit.status_file
         if status_file.exists() and not args.force:
             if not status_file.is_file():
                 info('Status file %s is not a file' % status_file)


### PR DESCRIPTION
This PR sets the config as a module attibute.

Instead of:

```python
from duqtools.config import Config as cfg
cfg().variable
```

use

```python
from duqtools.config import cfg
cfg.variable
```