### PR TITLE
Debug submit subcommand with tests on cluster

### DIFF
--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from getpass import getuser
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import yaml
@@ -174,6 +175,15 @@ class CreateConfig(BaseModel):
     data: DataLocation
 
 
+class WorkDirectory(BaseModel):
+    root: DirectoryPath = f'/pfs/work/{getuser()}/jetto/runs/'
+    subdirectory: str = 'workspace'
+
+    @property
+    def path(self):
+        return self.root / self.subdirectory
+
+
 class Config(BaseModel):
     """Config class containing all configs, is a singleton and can be used with
     import duqtools.config.Config as Cfg Cfg().<variable you want>"""
@@ -185,7 +195,7 @@ class Config(BaseModel):
     submit: SubmitConfig = SubmitConfig()
     create: Optional[CreateConfig]
     status: StatusConfig = StatusConfig()
-    workspace: DirectoryPath = './workspace'
+    workspace: WorkDirectory = WorkDirectory()
 
     def __new__(cls, *args, **kwargs):
         # Make it a singleton

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from getpass import getuser
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import yaml
@@ -177,11 +178,11 @@ class CreateConfig(BaseModel):
 
 class WorkDirectory(BaseModel):
     root: DirectoryPath = f'/pfs/work/{getuser()}/jetto/runs/'
-    subdirectory: str = 'workspace'
+    subdir: Path = Path('workspace')
 
     @property
     def path(self):
-        return self.root / self.subdirectory
+        return self.root / self.subdir
 
 
 class Config(BaseModel):

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import stat
 from pathlib import Path
 
 from duqtools.config import cfg
@@ -33,6 +34,11 @@ def copy_files(source_drc: Path, target_drc: Path):
         src = source_drc / filename
         dst = target_drc / filename
         shutil.copyfile(src, dst)
+
+    for filename in ('rjettov', 'utils_jetto'):
+        path = target_drc / filename
+        path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
     logger.debug('copied files to %s' % target_drc)
 
 

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -112,7 +112,9 @@ def status(**kwargs):
 
     debug('Submit config: %s' % cfg.submit)
 
-    dirs = [Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()]
+    dirs = [
+        Path(entry) for entry in scandir(cfg.workspace.path) if entry.is_dir()
+    ]
     debug('Case directories: %s' % dirs)
 
     info('Total number of directories: %i' % len(dirs))

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -24,7 +24,7 @@ def submit(**kwargs):
     debug('Submit config: %s' % cfg.submit)
 
     run_dirs = [
-        Path(entry) for entry in scandir(cfg.workspace) if entry.is_dir()
+        Path(entry) for entry in scandir(cfg.workspace.path) if entry.is_dir()
     ]
     debug('Case directories: %s' % run_dirs)
 

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,4 +1,6 @@
-workspace: ./workspace
+workspace:
+  root: /pfs/work/g2ssmee/jetto/runs
+  subdirectory: workspace
 create:
   template: template_model
   data:
@@ -15,3 +17,10 @@ create:
     - ids: profiles_1d/0/t_i_average
       operator: multiply
       values: [1.1, 1.2, 1.3]
+status:
+  msg_completed: 'Status : Completed successfully'
+  msg_failed: 'Status : Failed'
+  msg_running: 'Status : Running'
+submit:
+  status_file: jetto.status
+  submit_script_name: .llcmd

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,6 +1,6 @@
 workspace:
   root: /pfs/work/g2ssmee/jetto/runs
-  subdirectory: workspace
+  subdir: workspace
 create:
   template: template_model
   data:

--- a/tests/test_cmdline_config.yaml
+++ b/tests/test_cmdline_config.yaml
@@ -1,4 +1,6 @@
-workspace: ./workspace
+workspace:
+  root: .
+  subdir: workspace
 create:
   template: template_model
   data:
@@ -9,10 +11,10 @@ create:
     method: latin-hypercube
     n_samples: 3
   matrix:
-    - ids: zeff
+    - ids: profiles_1d/0/zeff
       operator: add
       values: [1, 2, 3]
-    - ids: t_i_average
+    - ids: profiles_1d/0/t_i_average
       operator: multiply
       values: [1.1, 1.2, 1.3]
 submit:


### PR DESCRIPTION
This PR fixes some issues I ran into when testing the submit subcommand on the Gateway.
The goal is to have a working create -> submit -> status workflow when this PR gets merged.

- Split workspace int root- and subdirectories
- Revise the .llcmd script creation
- Make jetto scripts executable

## Todo

- [x] Update other instances where workspace is used