### PR TITLE
Forbid extra keywords in config

### DIFF
--- a/duqtools/_types.py
+++ b/duqtools/_types.py
@@ -1,4 +1,13 @@
 import os
 from typing import TypeVar
 
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import Extra
+
 PathLike = TypeVar('PathLike', str, os.PathLike)
+
+
+class BaseModel(PydanticBaseModel):
+
+    class Config:
+        extra = Extra.forbid

--- a/duqtools/config.py
+++ b/duqtools/config.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import yaml
-from pydantic import BaseModel, DirectoryPath, Field
+from pydantic import DirectoryPath, Field
 from typing_extensions import Literal
 
-from ._types import PathLike
+from ._types import BaseModel, PathLike
 
 if TYPE_CHECKING:
     from .ids import IDSMapping

--- a/duqtools/ids/_location.py
+++ b/duqtools/ids/_location.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 
 import imas
 from imas import imasdef
-from pydantic import BaseModel
 
+from .._types import BaseModel
 from ._mapping import IDSMapping
 
 if TYPE_CHECKING:

--- a/duqtools/init.py
+++ b/duqtools/init.py
@@ -2,9 +2,10 @@ import logging
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel
 
 import duqtools.config
+
+from ._types import BaseModel
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR forbids extra keywords in the config. Use `from duqtools._types import BaseModel` instead of `from pydantic import BaseModel`.

Closes #92