### PR TITLE
Set default option for config (`duqtools.yaml`)

### DIFF
--- a/duqtools/__main__.py
+++ b/duqtools/__main__.py
@@ -17,24 +17,34 @@ coverage.process_startup()
 
 def cmdline():
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(conflict_handler='resolve')
 
     # Subparsers
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser('init',
-                                        help='Create a default config file')
+                                        help='Create a default config file',
+                                        parents=[parser],
+                                        conflict_handler='resolve')
     parser_init.set_defaults(func=init)
 
     parser_create = subparsers.add_parser('create',
-                                          help='Create the UQ run files')
+                                          help='Create the UQ run files',
+                                          parents=[parser],
+                                          conflict_handler='resolve')
     parser_create.set_defaults(func=create)
 
-    parser_submit = subparsers.add_parser('submit', help='Submit the UQ runs')
+    parser_submit = subparsers.add_parser('submit',
+                                          help='Submit the UQ runs',
+                                          parents=[parser],
+                                          conflict_handler='resolve')
     parser_submit.set_defaults(func=submit)
 
     parser_status = subparsers.add_parser(
-        'status', help='Print the status of the UQ runs')
+        'status',
+        help='Print the status of the UQ runs',
+        parents=[parser],
+        conflict_handler='resolve')
     parser_status.set_defaults(func=Status.status)
     parser_status.add_argument('--progress',
                                action='store_const',
@@ -46,16 +56,19 @@ def cmdline():
         'plot', help='Analyze the results and generate a report')
     parser_plot.set_defaults(func=plot)
 
-    # Globally required options
-    parser.add_argument('CONFIG', type=str, help='path to store run files')
-
     # Global optional options
+    parser.add_argument('-c',
+                        '--config',
+                        type=str,
+                        help='Path to config',
+                        default='duqtools.yaml')
     parser.add_argument('--debug',
                         action='store_const',
                         const=True,
                         default=False,
                         help='Enable debug print statements')
-    parser.add_argument('--force',
+    parser.add_argument('-f',
+                        '--force',
                         action='store_const',
                         const=True,
                         default=False,
@@ -72,7 +85,7 @@ def cmdline():
 
     # Load the config file
     if not args.func == init:  # dont read it if we have to create it
-        cfg.read(args.CONFIG)
+        cfg.read(args.config)
 
     # Run the subcommand
     args.func(args=args)

--- a/duqtools/init.py
+++ b/duqtools/init.py
@@ -22,7 +22,7 @@ def init(**kwargs):
     cfg = duqtools.config.Config()
     BaseModel.__init__(cfg)
     logger.debug(cfg)
-    config_filepath = Path(args.CONFIG)
+    config_filepath = Path(args.config)
     if config_filepath.exists() and not args.force:
         raise RuntimeError('Refusing to overwrite existing CONFIG, %s \
                     , use --force if you really want to' % config_filepath)


### PR DESCRIPTION
This PR sets a default config name (`duqtools.yaml`). It also re-organizes the argparser a bit, so that global variables are now actually global.

The config name can now be specified using `-c` or `--config`.

Closes #88 