### PR TITLE
Run commands / store output in current working directory

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -29,7 +29,7 @@ def load_profile(jset_file):
     return profile
 
 
-jset_files = list(cfg.workspace.path.glob('*/*.jset'))
+jset_files = list(cfg.workspace.cwd.glob('*/*.jset'))
 
 profiles = []
 for jset_file in jset_files:

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -50,10 +50,10 @@ def write_batchfile(workspace: WorkDirectory, run_name: str):
     target_drc : Path
         Directory to place batch file into.
     """
-    run_drc = workspace.path / run_name
+    run_drc = workspace.cwd / run_name
     llcmd_path = run_drc / '.llcmd'
 
-    full_path = workspace.path / run_name
+    full_path = workspace.cwd / run_name
     rjettov_path = full_path / 'rjettov'
     rel_path = workspace.subdir / run_name
 
@@ -98,7 +98,7 @@ def create(**kwargs):
 
     for i, combination in enumerate(combinations):
         run_name = f'run_{i:04d}'
-        run_drc = cfg.workspace.path / run_name
+        run_drc = cfg.workspace.cwd / run_name
         run_drc.mkdir(parents=True, exist_ok=True)
 
         copy_files(template_drc, run_drc)

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -24,7 +24,7 @@ def plot(**kwargs):
     # Gather all results and put them in a in-memory format
     # (they should be small enough)
     profiles = []
-    jset_files = list(cfg.workspace.path.glob('*/*.jset'))
+    jset_files = list(cfg.workspace.cwd.glob('*/*.jset'))
 
     for jset_file in jset_files:
         jset = JettoSettings.from_file(jset_file)

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -57,7 +57,7 @@ class Status():
         debug('Submit config: %s' % cfg.submit)
 
         self.dirs = [
-            Path(entry) for entry in scandir(cfg.workspace.path)
+            Path(entry) for entry in scandir(cfg.workspace.cwd)
             if entry.is_dir()
         ]
         debug('Case directories: %s' % self.dirs)

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -24,7 +24,7 @@ def submit(**kwargs):
     debug('Submit config: %s' % cfg.submit)
 
     run_dirs = [
-        Path(entry) for entry in scandir(cfg.workspace.path) if entry.is_dir()
+        Path(entry) for entry in scandir(cfg.workspace.cwd) if entry.is_dir()
     ]
     debug('Case directories: %s' % run_dirs)
 


### PR DESCRIPTION
This PR removes the `subdir` command from the working directory config. All programs now run in the current directory. The config validates the cwd to make sure it is relative to the root.

Closes #99