### PR TITLE
Make IDSMapping behave more like a dict

### DIFF
--- a/duqtools/ids/_location.py
+++ b/duqtools/ids/_location.py
@@ -27,6 +27,20 @@ SUFFIXES = (
 )
 
 
+def _patch_str_repr(obj: object):
+    """Reset str/repr methods to default."""
+    import types
+
+    def true_repr(x):
+        type_ = type(x)
+        module = type_.__module__
+        qualname = type_.__qualname__
+        return f'<{module}.{qualname} object at {hex(id(x))}>'
+
+    obj.__str__ = types.MethodType(true_repr, obj)  # type: ignore
+    obj.__repr__ = types.MethodType(true_repr, obj)  # type: ignore
+
+
 class ImasLocation(BaseModel):
     db: str
     run: int
@@ -110,6 +124,9 @@ class ImasLocation(BaseModel):
         """
         with self.open() as data_entry:
             data = data_entry.get(key)
+
+        # reset string representation because output is extremely lengthy
+        _patch_str_repr(data)
 
         return data
 


### PR DESCRIPTION
This PR updates the IDSMapping with a `__getitem__` method so that it behaves more like a dictionary. I also pruned the output from the raw ids, because it is extremely spammy.