### PR TITLE
Several tweaks in preparation for partial plots

### DIFF
--- a/duqtools/__main__.py
+++ b/duqtools/__main__.py
@@ -90,6 +90,13 @@ def cmdline():
         help='Delete generated IDS data and the run dirs',
         parents=[parser],
         conflict_handler='resolve')
+
+    parser_clean.add_argument('--out',
+                              action='store_const',
+                              const=True,
+                              default=False,
+                              help='Remove output data.')
+
     parser_clean.set_defaults(func=cleanup)
 
     # parse the arguments

--- a/duqtools/cleanup.py
+++ b/duqtools/cleanup.py
@@ -8,7 +8,7 @@ from .config import cfg
 logger = logging.getLogger(__name__)
 
 
-def cleanup(force: bool = False, **kwargs):
+def cleanup(force: bool = False, out: bool = False, **kwargs):
     """Read runs.yaml and clean the current directory.
 
     Parameters
@@ -20,8 +20,12 @@ def cleanup(force: bool = False, **kwargs):
     """
 
     for run in cfg.workspace.runs:
-        logger.info('Removing %s', run.data)
-        run.data.delete()
+        logger.info('Removing %s', run.data_in)
+        run.data_in.delete()
+
+        if out:
+            logger.info('Removing %s', run.data_out)
+            run.data_out.delete()
 
         logger.info('Removing run dir %s', run.dirname.resolve())
         shutil.rmtree(run.dirname)

--- a/duqtools/config/_runs.py
+++ b/duqtools/config/_runs.py
@@ -4,13 +4,15 @@ from typing import List
 
 from pydantic import DirectoryPath
 
-from .basemodel import BaseModel
 from duqtools.ids import IDSOperation, ImasLocation
+
+from .basemodel import BaseModel
 
 
 class Run(BaseModel):
     dirname: DirectoryPath
-    data: ImasLocation
+    data_in: ImasLocation
+    data_out: ImasLocation
     operations: List[IDSOperation]
 
 

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -167,7 +167,8 @@ def create(force: bool = False, **kwargs):
 
         runs.append({
             'dirname': run_name,
-            'data': target_in,
+            'data_in': target_in,
+            'data_out': target_out,
             'operations': combination
         })
 

--- a/duqtools/ids/_mapping.py
+++ b/duqtools/ids/_mapping.py
@@ -1,3 +1,4 @@
+import re
 from collections import defaultdict
 from collections.abc import Mapping
 
@@ -100,3 +101,22 @@ class IDSMapping(Mapping):
         for item in path[:-1]:
             cur = cur[item]
         cur[path[-1]] = val
+
+    def findall(self, pattern: str):
+        """Find keys matching regex pattern.
+
+        Parameters
+        ----------
+        pattern : str
+            Regex pattern
+
+        Returns
+        -------
+        dict
+            New dict with all matching key/value pairs.
+        """
+        pat = re.compile(pattern)
+        return {
+            key: self.flat_fields[key]
+            for key in self.flat_fields if pat.match(key)
+        }

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -30,6 +30,7 @@ def plot(**kwargs):
         jset = JettoSettings.from_file(jset_file)
         imas_loc = ImasLocation.from_jset_output(jset)
         info('Reading %s', imas_loc)
+
         profile = imas_loc.get_ids_tree('core_profiles')
         profiles.append(profile)
 
@@ -37,6 +38,10 @@ def plot(**kwargs):
         info('Creating plot number %04i', i)
 
         fig, ax = plt.subplots()
+
+        ax.set_title(plot.y)
+        ax.set_xlabel(plot.get_xlabel())
+        ax.set_ylabel(plot.get_ylabel())
 
         for j, profile in enumerate(profiles):
             y = profile.flat_fields[plot.y]
@@ -46,10 +51,7 @@ def plot(**kwargs):
             else:
                 x = np.linspace(0, 1, len(y))
 
-            ax.set_xlabel(plot.get_xlabel())
-            ax.set_ylabel(plot.get_ylabel())
-
             ax.plot(x, y, label=j)
 
         ax.legend()
-        fig.savefig(f'plot_{i:04d}.png', i)
+        fig.savefig(f'plot_{i:04d}.png')

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -32,6 +32,10 @@ def plot(**kwargs):
         info('Reading %s', imas_loc)
 
         profile = imas_loc.get_ids_tree('core_profiles')
+        if 'profiles_1d' not in profile:
+            logger.warning('No data in entry, skipping...')
+            continue
+
         profiles.append(profile)
 
     for i, plot in enumerate(cfg.plot.plots):

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -163,12 +163,13 @@ class Status():
         for i, dir in enumerate(self.dirs):
             pbars.append(tqdm(total=100, position=i))
             status = self.get_status(dir)
-            pbars[-1].set_description('%8s, status: %12s', dir.name, status)
+            pbars[-1].set_description(f'{dir.name:8s}, status: {dir.name:12s}')
 
         while len(self.dirs_completed) < len(self.dirs_submit):
             for i, dir in enumerate(self.dirs):
                 status = self.get_status(dir)
-                pbars[i].set_description('%8s, status: %12s', dir.name, status)
+                pbars[i].set_description(
+                    f'{dir.name:8s}, status: {status:12s}')
                 if dir in self.dirs_running:
                     pbars[i].n = completion_percentage(dir)
                 pbars[i].refresh()

--- a/tests/ids/test_mapping.py
+++ b/tests/ids/test_mapping.py
@@ -3,6 +3,8 @@ import pytest
 
 from duqtools.ids import IDSMapping
 
+assert_equal = np.testing.assert_array_equal
+
 
 class Sample:
     a = np.array((1, 2))
@@ -22,8 +24,6 @@ class Sample:
 def test_mapping():
     s = IDSMapping(Sample)
 
-    assert_equal = np.testing.assert_array_equal
-
     assert_equal(s.flat_fields['a'], np.array([1, 2]))
     assert_equal(s.flat_fields['b/c/d'], np.array([4, 5]))
     assert_equal(s.flat_fields['b/f/0'], np.array([6, 7]))
@@ -36,8 +36,34 @@ def test_mapping():
     assert_equal(s.fields['b']['f']['0'], np.array([6, 7]))
 
 
-@pytest.mark.xfail(reason='Unknown keys should raise a KeyError')
 def test_mapping_unknown_key_fail():
     s = IDSMapping(Sample)
     with pytest.raises(KeyError):
         s.fields['this key does not exist']
+
+
+def test_find_all():
+    s = IDSMapping(Sample)
+    d = s.findall('b/f/[0-9]')
+
+    assert len(d) == 2
+    assert 'b/f/0' in d
+    assert 'b/f/1' in d
+
+
+def test_find_group():
+    s = IDSMapping(Sample)
+    d = s.find_by_group(r'(b/f)/(\d)')
+
+    assert len(d) == 2
+    assert ('b/f', '0') in d
+    assert ('b/f', '1') in d
+
+
+def test_find_index():
+    s = IDSMapping(Sample)
+    lst = s.find_by_index('b/f/$i')
+
+    assert len(lst) == 2
+    assert_equal(lst[0], np.array([6, 7]))
+    assert_equal(lst[1], np.array([8, 9]))


### PR DESCRIPTION
This PR updates the IDSMapping to search for arbitrary keys using regexes. These either return a list of arrays (sorted by timestep) or dict keyed with regex groups.

It also:
1. Adds a command to `duqtools clean` to remove the data output by the UQ runs
2. Prevents new imasDB entries to be created automatically (fail instead)
3. Fixes a few small issues with how plots are generated

These are general improvements that I want to merge before starting to work on plotting/tracking partial outputs.

Addresses #98 