### PR TITLE
Mock imas import for readthedocs build

### DIFF
--- a/docs/dash.md
+++ b/docs/dash.md
@@ -8,7 +8,7 @@ This requires duqtools to be installed with additional dependencies:
 
 or, when installing the development version:
 
-`pip install -e .[dash]
+`pip install -e .[dash]`
 
 To run the command:
 

--- a/duqtools/ids/_copy.py
+++ b/duqtools/ids/_copy.py
@@ -3,7 +3,12 @@ import xml.sax
 import xml.sax.handler
 from getpass import getuser
 
-import imas
+try:
+    import imas
+except ImportError:
+    from unittest.mock import MagicMock as Mock
+    imas = Mock()
+
 from packaging import version
 
 from .._logging_utils import LoggingContext

--- a/duqtools/ids/_location.py
+++ b/duqtools/ids/_location.py
@@ -6,8 +6,13 @@ from getpass import getuser
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import imas
-from imas import imasdef
+try:
+    import imas
+    from imas import imasdef
+except ImportError:
+    from unittest.mock import MagicMock as Mock
+    imas = Mock()
+    imasdef = Mock()
 
 from duqtools.config.basemodel import BaseModel
 


### PR DESCRIPTION
This PR mocks the imas import to get the documentation to build. At the moment, `mkdocstrings` has no mocking system for the Python handler.

Closes #150