### PR TITLE
Tweak code box appearance (syntax highlights, titles)

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -16,9 +16,7 @@ To run the command:
 
 The options of the create subcommand are stored in the `create` key in the config. For example:
 
-
-```yaml
-# duqtools.yaml
+```yaml title="duqtools.yaml"
 create:
   template: template_model
   data:
@@ -35,8 +33,9 @@ create:
   sampler:
     method: latin-hypercube
     n_samples: 5
-
 ```
+
+
 
 `template`: The create subroutine takes as a template directory. This can be a directory with a finished run, or one just stored by JAMS (but not yet started). `duqtools` uses the input IDS machine (`db`) name, `user`, `shot`, `run` number from `jetto.in` to find the data to modify for the UQ runs.
 

--- a/docs/plot.md
+++ b/docs/plot.md
@@ -20,8 +20,7 @@ The options of the plot subcommand are stored under the `plot` key in the config
 
 For example:
 
-```yaml
-# duqtools.yaml
+```yaml title="duqtools.yaml"
 plots:
   - x:
     y: profiles_1d/0/electrons/density_thermal

--- a/docs/status.md
+++ b/docs/status.md
@@ -17,9 +17,8 @@ To run the command:
 The options of the status subcommand are stored under the `status` key in the config. These only need to be changed if the modeling softare changes.
 
 
-```yaml
-# duqtools.yaml
-status: # Configuration for the status subcommand
+```yaml title="duqtools.yaml"
+status:
   status_file: jetto.status
   msg_completed: 'Status : Completed successfully'
   msg_failed: 'Status : Failed'

--- a/docs/submit.md
+++ b/docs/submit.md
@@ -19,8 +19,7 @@ To run the command:
 The options of the submit subcommand are stored under the `submit` key in the config. For example:
 
 
-```yaml
-# duqtools.yaml
+```yaml title="duqtools.yaml"
 submit:
   submit_script_name: .llcmd
   submit_command:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ markdown_extensions:
   - admonition
   - mkdocs-click
   - attr_list
+  - pymdownx.superfences
 
 plugins:
 - search


### PR DESCRIPTION
This PR tweaks what code boxes look like using the [superfences pymarkdown extension](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/).