### PR TITLE
Move attributes from submit to status in config

### DIFF
--- a/duqtools/config/status.py
+++ b/duqtools/config/status.py
@@ -1,9 +1,31 @@
+from pydantic import Field
+
 from .basemodel import BaseModel
 
 
 class StatusConfig(BaseModel):
     """Status_config."""
 
-    msg_completed: str = 'Status : Completed successfully'
-    msg_failed: str = 'Status : Failed'
-    msg_running: str = 'Status : Running'
+    status_file: str = Field('jetto.status',
+                             description='Name of the status file.')
+    in_file: str = Field(
+        'jetto.in',
+        description='Name of the modelling input file, will be used to check'
+        ' if the subprocess has started.')
+    out_file: str = Field(
+        'jetto.out',
+        description='Name of the modelling output file, will be used to check'
+        ' if the subprocess is running,')
+
+    msg_completed: str = Field(
+        'Status : Completed successfully',
+        description='Parse `status_file` for this message to check for'
+        ' completion.')
+    msg_failed: str = Field(
+        'Status : Failed',
+        description='Parse `status_file` for this message to check for'
+        ' failures.')
+    msg_running: str = Field(
+        'Status : Running',
+        description='Parse `status_file` for this message to check for'
+        ' running status.')

--- a/duqtools/config/submit.py
+++ b/duqtools/config/submit.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from .basemodel import BaseModel
 
 
@@ -7,8 +9,6 @@ class SubmitConfig(BaseModel):
     Config class for submitting jobs
     """
 
-    submit_script_name: str = '.llcmd'
-    status_file: str = 'jetto.status'
-    out_file: str = 'jetto.out'
-    in_file: str = 'jetto.in'
-    submit_command: str = 'sbatch'
+    submit_script_name: str = Field(
+        '.llcmd', description='Name of the submission script.')
+    submit_command: str = Field('sbatch', description='Submission command.')

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -14,7 +14,7 @@ def has_submit_script(dir: Path) -> bool:
 
 
 def has_status(dir: Path) -> bool:
-    return (dir / cfg.submit.status_file).exists()
+    return (dir / cfg.status.status_file).exists()
 
 
 def is_submitted(dir: Path) -> bool:
@@ -22,7 +22,7 @@ def is_submitted(dir: Path) -> bool:
 
 
 def status_file_contains(dir: Path, msg) -> bool:
-    sf = (dir / cfg.submit.status_file)
+    sf = (dir / cfg.status.status_file)
     with open(sf, 'r') as f:
         content = f.read()
         debug('Checking if content of %s file: %s contains %s', sf, content,
@@ -43,8 +43,8 @@ def is_running(dir: Path) -> bool:
 
 
 def completion_percentage(dir: Path) -> int:
-    of = (dir / cfg.submit.out_file)
-    infile = (dir / cfg.submit.in_file)
+    of = (dir / cfg.status.out_file)
+    infile = (dir / cfg.status.in_file)
     if not of.exists():
         debug('%s does not exists, but the job is running', of)
         return 0

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -39,7 +39,7 @@ def submit(force: bool = False, **kwargs):
                  submission_script)
             continue
 
-        status_file = run_dir / cfg.submit.status_file
+        status_file = run_dir / cfg.status.status_file
         if status_file.exists() and not force:
             if not status_file.is_file():
                 info('Status file %s is not a file', status_file)

--- a/example/config-init.yaml
+++ b/example/config-init.yaml
@@ -15,7 +15,7 @@ status:
   msg_completed: 'Status : Completed successfully'
   msg_failed: 'Status : Failed'
   msg_running: 'Status : Running'
-submit:
   status_file: jetto.status
+submit:
   submit_script_name: .llcmd
 workspace: ./workspace

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -20,8 +20,8 @@ status:
   msg_completed: 'Status : Completed successfully'
   msg_failed: 'Status : Failed'
   msg_running: 'Status : Running'
-submit:
   status_file: jetto.status
+submit:
   submit_script_name: .llcmd
 plot:
   plots:

--- a/tests/test_cmdline_config.yaml
+++ b/tests/test_cmdline_config.yaml
@@ -17,4 +17,4 @@ create:
       operator: multiply
       values: [1.1, 1.2, 1.3]
 submit:
-  submit_command: ["true"]
+  submit_command: "true"


### PR DESCRIPTION
This PR moves some attributes from `submit`->`status`, where they are more appropriate.

Closes #147