### PR TITLE
Dry run support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.950'
+    rev: 'v0.961'
     hooks:
       - id: mypy

--- a/duqtools/cli.py
+++ b/duqtools/cli.py
@@ -39,8 +39,22 @@ def debug_option(f):
                         callback=callback)(f)
 
 
+def dry_run_option(f):
+
+    def callback(ctx, param, dry_run):
+        if dry_run:
+            logger.info('--dry-run enabled')
+
+        return dry_run
+
+    return click.option('--dry-run',
+                        is_flag=True,
+                        help='Execute without any side-effects.',
+                        callback=callback)(f)
+
+
 def common_options(func):
-    for wrapper in (debug_option, config_option):
+    for wrapper in (debug_option, config_option, dry_run_option):
         func = wrapper(func)
     return func
 

--- a/duqtools/cli.py
+++ b/duqtools/cli.py
@@ -43,7 +43,9 @@ def dry_run_option(f):
 
     def callback(ctx, param, dry_run):
         if dry_run:
+            from .config.system import DummySystem
             logger.info('--dry-run enabled')
+            cfg.system = DummySystem()
 
         return dry_run
 
@@ -55,6 +57,7 @@ def dry_run_option(f):
 
 def common_options(func):
     for wrapper in (debug_option, config_option, dry_run_option):
+        # config_option MUST BE BEFORE dry_run_option
         func = wrapper(func)
     return func
 

--- a/duqtools/config/system.py
+++ b/duqtools/config/system.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING
 from typing_extensions import Literal
 
 from .basemodel import BaseModel
+from .imaslocation import ImasLocation
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from ._runs import Run
     from ._workdir import WorkDirectory
-    from .imaslocation import ImasLocation
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class DummySystem(BaseModel, AbstractSystem):
 
     @staticmethod
     def get_imas_location(run: Run):
-        pass
+        return run.data_out
 
     @staticmethod
     def copy_from_template(source_drc: Path, target_drc: Path):
@@ -63,7 +63,7 @@ class DummySystem(BaseModel, AbstractSystem):
 
     @staticmethod
     def imas_from_path(template_drc: Path):
-        pass
+        return ImasLocation(db='', shot='-1', run='-1')
 
     @staticmethod
     def update_imas_locations(run: Path, inp: ImasLocation, out: ImasLocation):

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -25,7 +25,7 @@ def fail_if_locations_exist(locations: Iterable[ImasLocation]):
             'remove or `--force` to override.')
 
 
-def create(force, dry_run, **kwargs):
+def create(*, force, dry_run, **kwargs):
     """Create input for jetto and IDS data structures.
 
     Parameters

--- a/duqtools/init.py
+++ b/duqtools/init.py
@@ -8,7 +8,7 @@ from .config.basemodel import BaseModel
 logger = logging.getLogger(__name__)
 
 
-def init(dry_run, config, full, force, **kwargs):
+def init(*, dry_run, config, full, force, **kwargs):
     """Initialize a brand new config file with all the default values.
 
     Parameters

--- a/duqtools/init.py
+++ b/duqtools/init.py
@@ -8,10 +8,7 @@ from .config.basemodel import BaseModel
 logger = logging.getLogger(__name__)
 
 
-def init(config: str = 'config.yaml',
-         full: bool = False,
-         force: bool = False,
-         **kwargs):
+def init(dry_run, config, full, force, **kwargs):
     """Initialize a brand new config file with all the default values.
 
     Parameters
@@ -50,5 +47,6 @@ def init(config: str = 'config.yaml',
                                 'plot': {'plots'}
                             })
 
-    with open(config_filepath, 'w') as f:
-        f.write(cfg_yaml)
+    if not dry_run:
+        with open(config_filepath, 'w') as f:
+            f.write(cfg_yaml)

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
-def plot(dry_run, **kwargs):
+def plot(*, dry_run, **kwargs):
     """Plot subroutine to create plots from datas."""
     import matplotlib.pyplot as plt
     import numpy as np

--- a/duqtools/plot.py
+++ b/duqtools/plot.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
-def plot(**kwargs):
+def plot(dry_run, **kwargs):
     """Plot subroutine to create plots from datas."""
     import matplotlib.pyplot as plt
     import numpy as np
@@ -48,4 +48,5 @@ def plot(**kwargs):
             ax.plot(x, y, label=j)
 
         ax.legend()
-        fig.savefig(f'plot_{i:04d}.png')
+        if not dry_run:
+            fig.savefig(f'plot_{i:04d}.png')

--- a/duqtools/status.py
+++ b/duqtools/status.py
@@ -179,7 +179,7 @@ class Status():
             self.update_status()
 
 
-def status(progress: bool, detailed: bool, **kwargs):
+def status(*, progress: bool, detailed: bool, **kwargs):
     """Show status of runs.
 
     Parameters

--- a/duqtools/submit.py
+++ b/duqtools/submit.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
-def submit(force: bool = False, **kwargs):
+def submit(*, force: bool, **kwargs):
     """submit. Function which implements the functionality to submit jobs to
     the cluster.
 

--- a/tests/dry_run.yaml
+++ b/tests/dry_run.yaml
@@ -1,24 +1,28 @@
 plot:  # Configuration for the plotting subcommand
   plots:
-  - x: profiles_1d/0/grid/rho_tor  # Data on x-axis, default is the toroidal flux coordiante
-    y: profiles_1d/0/electrons/density_thermal # Data on y-axis
+  - x: profiles_1d/0/grid/rho_tor_norm  # IDS of the data to plot on the x-axis, default is rho toroidal norm.
+    y: profiles_1d/0/electrons/density_thermal # IDS of the data to plot on the y-axis
     xlabel: # Custom label for x-axis
     ylabel: # Custom label for y-axis
+  - x: profiles_1d/0/grid/rho_tor_norm  # IDS of the data to plot on the x-axis, default is rho toroidal norm.
+    y: profiles_1d/0/t_i_average # IDS of the data to plot on the y-axis
+    xlabel: Rho tor. # Custom label for x-axis
+    ylabel: Ion temperature # Custom label for y-axis
 create: # Configuration for the create subcommand
-  matrix:  # Defines the space to sample
-  - operator: multiply  # Operation applied to the ids
-    ids: profiles_1d/0/t_i_average # Field within ids described in template dir from which to sample.
+  matrix:  # The `matrix` specifies the operations to apply. These are compound operations which are expanded to fill a matrix of all possible combinations. This generates the [Cartesian product](en.wikipedia.org/wiki/Cartesian_product) of all operations. By specifying a different `sampler`, a subset of this hypercube can be efficiently sampled.
+  - operator: multiply  # Which operator to apply to the data in combination with any of the given values below. This can be any of the basic numpy arithmetic operations. Available choices: `add`, `multiply`, `divide`, `power`, `subtract`, `floor_divide`, `mod`, and `remainder`. These directly map to the equivalent numpy functions, i.e. `add` -> `np.add`.
+    ids: profiles_1d/0/t_i_average # IDS Path of the data to modify. `core_profiles` is implied.
     values: # Values to use with operator on field to create sampling space.
     - 1.1
     - 1.2
     - 1.3
-  - sampling: normal  # Sampling method.
-    bounds: symmetric # Specify `symmetric` or `asymmetric` sampling. Use `auto` to choose `asymmetric` if the lower bounds are defined, else `symmetric`.
-    ids: profiles_1d/0/t_i_average # Field within ids described in template dir from which to sample.
+  - distribution: normal  # Sample from given distribution. Currently `normal` is the only option.
+    bounds: symmetric # Specify `symmetric` or `asymmetric` sampling. Use `auto` to choose `asymmetric` if the lower bounds are defined, else `symmetric`. The bounds are defiend by `$IDS_error_upper` and `$IDS_error_lower` in the data specification. Symmetric sampling sampling when both the lower and upper error bounds are present, takes the average of the two.
+    ids: profiles_1d/0/t_i_average # IDS Path of the data to modify. `core_profiles` is implied.
     n_samples: 5 # Number of samples to get.
-  sampler:
-    method: latin-hypercube  # Method to select samples, default: latin-hypercube, also supports: halton, sobol, cartesian-product
-    n_samples: 3 # Number of samples to take
-  template: /pfs/work/g2ssmee/jetto/runs/duqtools_template # run-case to use as template for all the other runs
+  sampler: # For efficient UQ, it may not be necessary to sample the entire matrix or hypercube. By default, the cartesian product is taken. For more efficient sampling of the space, the following `method` choices are available: [`latin-hypercube`](en.wikipedia.org/wiki/Latin_hypercube_sampling), [`sobol`](en.wikipedia.org/wiki/Sobol_sequence), [`halton`](en.wikipedia.org/wiki/Halton_sequence). Where `n_samples` gives the number of samples to extract.
+    method: latin-hypercube
+    n_samples: 3  # Number of samples to take
+  template: /pfs/work/g2ssmee/jetto/runs/duqtools_template # The create subroutine takes as a template directory. This can be a directory with a finished run, or one just stored by JAMS (but not yet started). Duqtools uses the input IDS machine (db) name, user, shot, run number from e.g. `jetto.in` to find the data to modify for the UQ runs.
 workspace:
-  root: . # The folder from which experiments have to be run, rjettov runs relative to this folder
+  root: .  # The folder from which experiments have to be run, rjettov runs relative to this folder

--- a/tests/dry_run.yaml
+++ b/tests/dry_run.yaml
@@ -1,0 +1,24 @@
+plot:  # Configuration for the plotting subcommand
+  plots:
+  - x: profiles_1d/0/grid/rho_tor  # Data on x-axis, default is the toroidal flux coordiante
+    y: profiles_1d/0/electrons/density_thermal # Data on y-axis
+    xlabel: # Custom label for x-axis
+    ylabel: # Custom label for y-axis
+create: # Configuration for the create subcommand
+  matrix:  # Defines the space to sample
+  - operator: multiply  # Operation applied to the ids
+    ids: profiles_1d/0/t_i_average # Field within ids described in template dir from which to sample.
+    values: # Values to use with operator on field to create sampling space.
+    - 1.1
+    - 1.2
+    - 1.3
+  - sampling: normal  # Sampling method.
+    bounds: symmetric # Specify `symmetric` or `asymmetric` sampling. Use `auto` to choose `asymmetric` if the lower bounds are defined, else `symmetric`.
+    ids: profiles_1d/0/t_i_average # Field within ids described in template dir from which to sample.
+    n_samples: 5 # Number of samples to get.
+  sampler:
+    method: latin-hypercube  # Method to select samples, default: latin-hypercube, also supports: halton, sobol, cartesian-product
+    n_samples: 3 # Number of samples to take
+  template: /pfs/work/g2ssmee/jetto/runs/duqtools_template # run-case to use as template for all the other runs
+workspace:
+  root: . # The folder from which experiments have to be run, rjettov runs relative to this folder

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -68,4 +68,4 @@ def test_example_plot(cmdline_workdir):
     with work_directory(cmdline_workdir):
         result = subprocess.run(cmd)
         assert (result.returncode == 0)
-        assert (os.path.exists('plot_0000.png'))
+        assert (Path('./plot_0000.png').exists())

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -39,6 +39,7 @@ def test_init(cmdline_workdir):
         assert (not Path('./duqtools.yaml').exists())
 
 
+@pytest.mark.dependency()
 def test_create(cmdline_workdir):
     with work_directory(cmdline_workdir):
         cli_create(['-c', 'config.yaml', '--dry-run', '--force'],
@@ -50,9 +51,10 @@ def test_create(cmdline_workdir):
 
 
 @pytest.mark.dependency(depends=['test_create'])
+@pytest.mark.dependency()
 def test_real_create(cmdline_workdir):
     with work_directory(cmdline_workdir):
-        cli_create(['-c', 'config.yaml'], standalone_mode=False)
+        cli_create(['-c', 'config.yaml', '--force'], standalone_mode=False)
         assert (Path('./run_0000').exists())
         assert (Path('./run_0001').exists())
         assert (Path('./run_0002').exists())

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,75 @@
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from duqtools.cli import cli_create, cli_init, cli_plot, cli_submit
+from duqtools.utils import work_directory
+
+
+@pytest.fixture(scope='session', autouse=True)
+def extra_env():
+    # Add required coverage env variable to each test
+    os.environ['COVERAGE_PROCESS_START'] = str(Path.cwd() / 'setup.cfg')
+
+
+@pytest.fixture(scope='session', autouse=True)
+def collect_cov(cmdline_workdir):
+    yield None
+    # Executed at end of session, but before closure of cmdline_workdir
+    for cov_file in cmdline_workdir.glob('.coverage.*'):
+        shutil.copy(cov_file, Path.cwd())
+
+
+@pytest.fixture(scope='session')
+def cmdline_workdir(tmp_path_factory):
+    # Create working directory for cmdline tests, and set up input files
+    workdir = tmp_path_factory.mktemp('test_cmdline')
+    (workdir / Path('workspace')).mkdir()
+    shutil.copy(Path.cwd() / 'tests' / 'dry_run.yaml', workdir / 'config.yaml')
+    shutil.copytree(Path.cwd() / 'example' / 'template_model',
+                    workdir / Path('template_model'))
+    return workdir
+
+
+def test_init(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        cli_init(['--full', '--dry-run'], standalone_mode=False)
+        assert (not Path('./duqtools.yaml').exists())
+
+
+def test_create(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        cli_create(['-c', 'config.yaml', '--dry-run', '--force'],
+                   standalone_mode=False)
+        assert (not Path('./run_0000').exists())
+        assert (not Path('./run_0001').exists())
+        assert (not Path('./run_0002').exists())
+        assert (not Path('./runs.yaml').exists())
+
+
+@pytest.mark.dependency(depends=['test_create'])
+def test_real_create(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        cli_create(['-c', 'config.yaml'], standalone_mode=False)
+        assert (Path('./run_0000').exists())
+        assert (Path('./run_0001').exists())
+        assert (Path('./run_0002').exists())
+        assert (Path('./runs.yaml').exists())
+
+
+@pytest.mark.dependency(depends=['test_real_create'])
+def test_submit(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        cli_submit(['-c', 'config.yaml', '--dry-run'], standalone_mode=False)
+        assert (not Path('./run_0000/duqtools.lock').exists())
+        assert (not Path('./run_0001/duqtools.lock').exists())
+        assert (not Path('./run_0002/duqtools.lock').exists())
+
+
+@pytest.mark.dependency(depends=['test_real_create'])
+def test_plot(cmdline_workdir):
+    with work_directory(cmdline_workdir):
+        cli_plot(['-c', 'config.yaml', '--dry-run'], standalone_mode=False)
+        assert (not Path('./plot_0000.png').exists())


### PR DESCRIPTION
This implements dry runs with a CLI Flag, Perhaps it is better to use a program-wide config flag, but this works and there are tests. Specifically annoying are the IDS operations which are in a database somewhere.

- [ ] Currently IDS-write operations are if-ed out, but we might move this to `inside` the Imas Class
- [ ] Perhaps it is not a good idea to use the DummySystem for dry-run, as it also changes some behavioural properties of the systems that we try to emulate