### PR TITLE
Split template location

### DIFF
--- a/docs/gendocs.py
+++ b/docs/gendocs.py
@@ -49,13 +49,16 @@ if 'plot' in models:
     extra_schemas['plot_schema'] = PlotModel.schema()
 
 if 'create' in models:
-    from duqtools.schema import ARange, IDSOperationDim, LinSpace
+    from duqtools.schema import (ARange, IDSOperationDim, ImasBaseModel,
+                                 LinSpace)
 
     extra_schemas['ops_schema'] = IDSOperationDim.schema()
     extra_schemas['data_loc_schema'] = cfg.create.data.schema()
 
     extra_schemas['linspace_schema'] = LinSpace.schema()
     extra_schemas['arange_schema'] = ARange.schema()
+
+    extra_schemas['imas_basemodel_schema'] = ImasBaseModel.schema()
 
     extra_yamls['data_loc_yaml'] = model2config('data', cfg.create.data)
 

--- a/docs/templates/template_create.md
+++ b/docs/templates/template_create.md
@@ -24,6 +24,34 @@ For example:
 {{ yaml_example }}
 ```
 
+
+## Specify the template data
+
+By default the template IMAS data to modify is extracted from the path specified in the `template` field.
+
+```yaml title="duqtools.yaml"
+template: /pfs/work/stef/jetto/runs/duqtools_template
+```
+
+In some cases, it may be useful to re-use the same set of model settings, but with different input data. If the `template_data` field is specified, these data will be used instead. To do so, specify `template_data` with the fields below:
+
+{% for name, prop in imas_basemodel_schema['properties'].items() %}
+`{{ name }}`
+: {{ prop['description'] }}
+{% endfor %}
+
+For example:
+
+```yaml title="duqtools.yaml"
+template: /pfs/work/g2ssmee/jetto/runs/duqtools_template
+template_data:
+  user: g2ssmee
+  db: jet
+  shot: 91234
+  run: 5
+```
+
+
 ## Data location
 
 {{ data_loc_schema['description'] }}
@@ -78,7 +106,7 @@ With the default `sampler: latin-hypercube`, this means 9 new data files will be
 
     The python equivalent is essentially `np.<operator>(ids, value, out=ids)` for each of the given values.
 
-### Specifying value ranges
+### Specify value ranges
 
 Although it is possible to specify value ranges explicitly in an operator, sometimes it may be easier to specify a range.
 
@@ -149,4 +177,4 @@ scale_to_error: True
 
 !!! note
 
-    When specifying a sigma range, make sure you use `add` as the operator. While the other operators are also supported, they do not make much sense in this context.
+    When you specify a sigma range, make sure you use `add` as the operator. While the other operators are also supported, they do not make much sense in this context.

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -50,7 +50,7 @@ def create(*, force, dry_run, **kwargs):
 
     system = get_system()
 
-    if not options.templat_data:
+    if not options.template_data:
         source = system.imas_from_path(template_drc)
     else:
         source = ImasHandle.parse_obj(options.template_data)

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -50,7 +50,11 @@ def create(*, force, dry_run, **kwargs):
 
     system = get_system()
 
-    source = system.imas_from_path(template_drc)
+    if not options.templat_data:
+        source = system.imas_from_path(template_drc)
+    else:
+        source = ImasHandle.parse_obj(options.template_data)
+
     logger.info('Source data: %s', source)
 
     matrix = tuple(dim.expand() for dim in dimensions)

--- a/duqtools/schema/_imas.py
+++ b/duqtools/schema/_imas.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from getpass import getuser
 
+from pydantic import Field
+
 from ._basemodel import BaseModel
 
 
 class ImasBaseModel(BaseModel):
-    user: str = getuser()
-    db: str
-    shot: int
-    run: int
+    """This model describes an IMAS data location."""
+    user: str = Field(getuser(), description='Username.')
+    db: str = Field(None, description='IMAS db/machine name.')
+    shot: int = Field(None, description='IMAS Shot number.')
+    run: int = Field(None, description='IMAS Run number.')

--- a/duqtools/schema/cli.py
+++ b/duqtools/schema/cli.py
@@ -7,6 +7,7 @@ from typing_extensions import Literal
 from ._basemodel import BaseModel
 from ._description_helpers import formatter as f
 from ._dimensions import IDSOperationDim
+from ._imas import ImasBaseModel
 from ._plot import PlotModel
 from .data_location import DataLocation
 from .matrix_samplers import (CartesianProduct, HaltonSampler, LHSSampler,
@@ -57,11 +58,19 @@ class CreateConfigModel(BaseModel):
     template: DirectoryPath = Field(
         f'/pfs/work/{getuser()}/jetto/runs/duqtools_template',
         description=f("""
-        The create subroutine takes as a template directory. This can be a
+        Template directory to modify. Duqtools copies and updates the settings
+        required for the specified system from this directory. This can be a
         directory with a finished run, or one just stored by JAMS (but not yet
-        started). Duqtools uses the input IDS machine (db) name, user, shot,
-        run number from e.g. `jetto.in` to find the data to modify for the
-        UQ runs.
+        started). By default, duqtools extracts the input IMAS database entry
+        from the settings file (e.g. jetto.in) to find the data to modify for
+        the UQ runs.
+        """))
+
+    template_data: ImasBaseModel = Field(None,
+                                         description=f("""
+        Specify the location of the template data to modify. This overrides the
+        location of the data specified in settings file in the template
+        directory.
         """))
 
     data: DataLocation = Field(DataLocation(),


### PR DESCRIPTION
This PR enables a new `template_data` location to be specified. This overrided whatever is in the template directory.

Closes #178