### PR TITLE
Operations queue

### DIFF
--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -7,6 +7,7 @@ from .ids import IDSMapping, ImasHandle
 from .ids.dimensions import apply_model
 from .matrix_samplers import get_matrix_sampler
 from .models import WorkDirectory
+from .operations import confirm_operations, op_queue
 from .schema.runs import Runs
 from .system import get_system
 
@@ -28,6 +29,26 @@ def fail_if_locations_exist(locations: Iterable[ImasHandle]):
             'remove or `--force` to override.')
 
 
+def apply_combination(target_in: ImasHandle, combination) -> None:
+    core_profiles = target_in.get('core_profiles')
+    ids_mapping = IDSMapping(core_profiles)
+
+    for model in combination:
+        apply_model(model, ids_mapping)
+
+        logger.info('Writing data entry: %s', target_in)
+        with target_in.open() as data_entry_target:
+            core_profiles.put(db_entry=data_entry_target)
+
+
+def write_runs_file(runs: list, workspace) -> None:
+
+    runs = Runs.parse_obj(runs)
+    with open(workspace.runs_yaml, 'w') as f:
+        runs.yaml(stream=f)
+
+
+@confirm_operations
 def create(*, force, dry_run, **kwargs):
     """Create input for jetto and IDS data structures.
 
@@ -75,8 +96,10 @@ def create(*, force, dry_run, **kwargs):
     for i, combination in enumerate(combinations):
         run_name = f'{RUN_PREFIX}{i:04d}'
         run_drc = workspace.cwd / run_name
-        if not dry_run:
-            run_drc.mkdir(parents=True, exist_ok=force)
+
+        op_queue.add(action=lambda run_drc=run_drc: run_drc.mkdir(
+            parents=True, exist_ok=force),
+                     description=f'Create folder {run_drc}')
 
         target_in = ImasHandle(db=options.data.db,
                                shot=source.shot,
@@ -85,25 +108,28 @@ def create(*, force, dry_run, **kwargs):
                                 shot=source.shot,
                                 run=options.data.run_out_start_at + i)
 
-        source.copy_ids_entry_to(target_in)
+        op_queue.add(action=lambda: source.copy_ids_entry_to(target_in),
+                     description=f'Create {target_in} from {source}')
 
-        core_profiles = target_in.get('core_profiles')
-        ids_mapping = IDSMapping(core_profiles)
+        op_queue.add(
+            action=lambda combination=combination, target_in=target_in,
+            target_out=target_out: apply_combination(target_in, combination),
+            description=f'Applying combination {combination} to {target_in}')
 
-        if not dry_run:
-            for model in combination:
-                apply_model(model, ids_mapping)
+        op_queue.add(
+            action=lambda run_drc=run_drc: system.copy_from_template(
+                template_drc, run_drc),
+            description=f'Copying template from {template_drc} to {run_drc}')
 
-            logger.info('Writing data entry: %s', target_in)
-            with target_in.open() as data_entry_target:
-                core_profiles.put(db_entry=data_entry_target)
+        op_queue.add(action=lambda run_name=run_name: system.write_batchfile(
+            workspace, run_name),
+                     description=f'Writing new batchfile for {run_name}')
 
-        system.copy_from_template(template_drc, run_drc)
-        system.write_batchfile(workspace, run_name)
-
-        system.update_imas_locations(run=run_drc,
-                                     inp=target_in,
-                                     out=target_out)
+        op_queue.add(action=lambda run_drc=run_drc, target_in=target_in,
+                     target_out=target_out: system.update_imas_locations(
+                         run=run_drc, inp=target_in, out=target_out),
+                     description=f'Updating imas locations of {run_drc} to \n'
+                     'in: {target_in}\nout: {target_out}')
 
         runs.append({
             'dirname': run_name,
@@ -112,8 +138,5 @@ def create(*, force, dry_run, **kwargs):
             'operations': combination
         })
 
-    if not dry_run:
-        runs = Runs.parse_obj(runs)
-
-        with open(workspace.runs_yaml, 'w') as f:
-            runs.yaml(stream=f)
+    op_queue.add(action=lambda: write_runs_file(runs, workspace),
+                 description=f'Writing out {workspace.runs_yaml}')

--- a/duqtools/create.py
+++ b/duqtools/create.py
@@ -109,17 +109,16 @@ def create(*, force, dry_run, **kwargs):
                                 run=options.data.run_out_start_at + i)
 
         op_queue.add(action=lambda: source.copy_ids_entry_to(target_in),
-                     description=f'Create {target_in} from {source}')
+                     description=f'Create {target_in} from template')
 
         op_queue.add(
             action=lambda combination=combination, target_in=target_in,
             target_out=target_out: apply_combination(target_in, combination),
-            description=f'Applying combination {combination} to {target_in}')
+            description=f'Applying combination to {target_in}')
 
-        op_queue.add(
-            action=lambda run_drc=run_drc: system.copy_from_template(
-                template_drc, run_drc),
-            description=f'Copying template from {template_drc} to {run_drc}')
+        op_queue.add(action=lambda run_drc=run_drc: system.copy_from_template(
+            template_drc, run_drc),
+                     description=f'Copying template to {run_drc}')
 
         op_queue.add(action=lambda run_name=run_name: system.write_batchfile(
             workspace, run_name),
@@ -128,8 +127,7 @@ def create(*, force, dry_run, **kwargs):
         op_queue.add(action=lambda run_drc=run_drc, target_in=target_in,
                      target_out=target_out: system.update_imas_locations(
                          run=run_drc, inp=target_in, out=target_out),
-                     description=f'Updating imas locations of {run_drc} to \n'
-                     'in: {target_in}\nout: {target_out}')
+                     description=f'Updating imas locations of {run_drc}')
 
         runs.append({
             'dirname': run_name,

--- a/duqtools/operations.py
+++ b/duqtools/operations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from queue import SimpleQueue
 from typing import Callable
 
@@ -7,8 +8,12 @@ from pydantic import Field
 
 from .schema import BaseModel
 
+logger = logging.getLogger(__name__)
+
 
 class Operation(BaseModel):
+    """Operation, simple class which has a callable action."""
+
     description: str = Field(
         description='description of the operation to be done')
     action: Callable = Field(
@@ -16,6 +21,7 @@ class Operation(BaseModel):
         'decide to apply this operation')
 
     def __call__(self) -> Operation:
+        logger.info(f'-: {self.description}')
         self.action()
         return self
 
@@ -31,6 +37,11 @@ class Operations(SimpleQueue):
         if not Operations._instance:
             Operations._instance = super().__new__(cls)
         return Operations._instance
+
+    def add(self, action: Callable, description: str) -> None:
+        """convenience wrapper around put."""
+
+        self.put(Operation(action=action, description=description))
 
     def put(self, item: Operation) -> None:  # type: ignore
         """Restrict our diet to Operation objects only."""
@@ -49,3 +60,15 @@ class Operations(SimpleQueue):
 
 
 op_queue = Operations()
+
+
+def confirm_operations(func):
+    """Decorator which confirms and applies queued operations after the
+    function."""
+
+    def wrapper(*args, **kwargs):
+        ret = func(*args, **kwargs)
+        op_queue.apply_all()
+        return ret
+
+    return wrapper

--- a/duqtools/operations.py
+++ b/duqtools/operations.py
@@ -44,6 +44,10 @@ class Operations(deque):
 
         self.append(Operation(action=action, description=description))
 
+    def put(self, item: Operation) -> None:
+        """synonym for append."""
+        self.append(item)
+
     def append(self, item: Operation) -> None:  # type: ignore
         """Restrict our diet to Operation objects only."""
 

--- a/duqtools/operations.py
+++ b/duqtools/operations.py
@@ -1,0 +1,45 @@
+from queue import SimpleQueue
+from typing import Callable
+
+from overloading import overload
+from pydantic import Field
+
+from .schema import BaseModel
+
+
+class Operation(BaseModel):
+    description: str = Field(
+        description='description of the operation to be done')
+    action: Callable = Field(
+        description='a function which can be executed when we '
+        'decide to apply this operation')
+
+
+class Operations(SimpleQueue):
+    """Operations Queue which keeps track of all the operations that need to be
+    done."""
+
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        # Make it a singleton
+        if not Operations._instance:
+            Operations._instance = object.__new__(cls)
+        return Operations._instance
+
+    @overload
+    def put(self, item: Operation) -> None:
+        """Restrict our diet to Operation objects only."""
+        super().put(self, item)
+
+    def apply(self):
+        """Apply the next operation in the queue and remove it."""
+        self.get()()
+
+    def apply_all(self):
+        """Apply all queued operations and empty the queue."""
+        while not self.empty():
+            self.apply()
+
+
+op_queue = Operations()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,61 @@
+from duqtools.operations import Operation, op_queue
+
+
+def test_touch_operation(tmp_path):
+    test_file = tmp_path / 'test'
+
+    action = test_file.touch
+    operation = Operation(action=action, description='touching test file')
+    op_queue.put(operation)
+
+    assert (not test_file.exists())
+
+    op_queue.apply()
+
+    assert (test_file.exists())
+
+
+def test_multiple_operation(tmp_path):
+    test_file = tmp_path / 'test'
+    test_file2 = tmp_path / 'test2'
+
+    op_queue.put(
+        Operation(action=test_file.touch, description='touching test file'))
+    op_queue.put(
+        Operation(action=test_file2.touch, description='touching test file2'))
+
+    assert (not test_file.exists())
+    assert (not test_file2.exists())
+    op_queue.apply()
+    assert (test_file.exists())
+    assert (not test_file2.exists())
+    op_queue.apply()
+    assert (test_file.exists())
+    assert (test_file2.exists())
+
+
+def test_operation_description(tmp_path):
+    test_file = tmp_path / 'test'
+
+    op_queue.put(
+        Operation(action=test_file.touch, description='touching test file'))
+
+    assert (not test_file.exists())
+    op = op_queue.apply()
+    assert (op.description == 'touching test file')
+
+
+def test_operation_apply_all(tmp_path):
+    test_file = tmp_path / 'test'
+    test_file2 = tmp_path / 'test2'
+
+    op_queue.put(
+        Operation(action=test_file.touch, description='touching test file'))
+    op_queue.put(
+        Operation(action=test_file2.touch, description='touching test file2'))
+
+    assert (not test_file.exists())
+    assert (not test_file2.exists())
+    op_queue.apply_all()
+    assert (test_file.exists())
+    assert (test_file2.exists())


### PR DESCRIPTION
Operations Queue
Implemented in:
- [ ] create
- [ ] submit
- [ ] init
- [ ] plot

- [ ] legacy --dry-run option removed

- [ ] move operations queue deeper into the System (and not in the "top" level functions