### PR TITLE
Enable setting values in `IDSMapping`

### DIFF
--- a/src/duqtools/ids/_dimensions.py
+++ b/src/duqtools/ids/_dimensions.py
@@ -37,17 +37,17 @@ def _(model: IDSOperation, ids_mapping: IDSMapping) -> None:
 
     npfunc = getattr(np, model.operator)
 
-    profile = ids_mapping.flat_fields[model.ids]
+    profile = ids_mapping[model.ids]
 
     if model.scale_to_error:
         sigma_key = model.ids + model._upper_suffix
 
         if model.value < 0:
             lower_key = model.ids + model._lower_suffix
-            if lower_key in ids_mapping.flat_fields:
+            if lower_key in ids_mapping:
                 sigma_key = lower_key
 
-        sigma_bound = ids_mapping.flat_fields[sigma_key]
+        sigma_bound = ids_mapping[sigma_key]
         sigma = abs(sigma_bound - profile)
 
         value = sigma * model.value

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Dict, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Sequence, Set, Tuple, Union
 
 import numpy as np
 
@@ -11,6 +11,8 @@ from ._constants import TIME_COL, TSTEP_COL
 
 if TYPE_CHECKING:
     import pandas as pd
+
+    from ._handle import ImasHandle
 
 
 def insert_re_caret_dollar(string: str) -> str:
@@ -22,28 +24,6 @@ def insert_re_caret_dollar(string: str) -> str:
     return string
 
 
-def recursive_defaultdict():
-    """Recursive defaultdict."""
-    return defaultdict(recursive_defaultdict)
-
-
-def defaultdict_to_dict(ddict: defaultdict):
-    """defaultdict_to_dict, turns a nested defaultdict into a nested dict.
-
-    Parameters
-    ----------
-    ddict : defaultdict
-        ddict
-    """
-
-    # Convert members to dict first
-    for k, v in ddict.items():
-        if isinstance(v, defaultdict):
-            ddict[k] = defaultdict_to_dict(v)
-    # Finally convert self to dict
-    return dict(ddict)
-
-
 class IDSMapping(Mapping):
 
     def __init__(self, ids, exclude_empty: bool = True):
@@ -51,37 +31,67 @@ class IDSMapping(Mapping):
         self.exclude_empty = exclude_empty
 
         # All fields in the core profile in a single dict
-        self.flat_fields: dict = {}
-
-        # All fields, in the core profile in a nested dict
-        self.fields: dict = defaultdict(recursive_defaultdict)
+        self._keys: Set[str] = set()
 
         self.dive(ids, [])
-        self.fields = defaultdict_to_dict(self.fields)
 
     def __repr__(self):
         s = f'{self.__class__.__name__}(\n'
-        for key in self.fields.keys():
+        for key in self._keys:
             s += f'  {key} = ...\n'
         s += ')\n'
 
         return s
 
     def __getitem__(self, key: str):
-        try:
-            return self.flat_fields[key]
-        except KeyError:
-            pass
-        try:
-            return self.fields[key]
-        except KeyError:
-            raise
+        if key not in self._keys:
+            raise KeyError(key)
+
+        *parts, attr = key.split('/')
+
+        pointer = self._ids
+
+        for part in parts:
+            try:
+                i = int(part)
+            except ValueError:
+                pointer = getattr(pointer, part)
+            else:
+                pointer = pointer[i]
+
+        return getattr(pointer, attr)
+
+    def __setitem__(self, key: str, value: np.ndarray):
+        if key not in self._keys:
+            return f'Cannot set non-existant key: {key}'
+
+        *parts, attr = key.split('/')
+
+        pointer = self._ids
+
+        for part in parts:
+            try:
+                i = int(part)
+            except ValueError:
+                pointer = getattr(pointer, part)
+            else:
+                pointer = pointer[i]
+
+        setattr(pointer, attr, value)
 
     def __iter__(self):
-        yield from self.fields
+        yield from self._keys
 
     def __len__(self):
-        return len(self.fields)
+        return len(self._keys)
+
+    def sync(self, handle: ImasHandle):
+        """Synchronize updated data back to IMAS db entry.
+
+        Shortcut for 'put' command.
+        """
+        with handle.open() as f:
+            self._ids.put(db_entry=f)
 
     def dive(self, val, path: list):
         """Recursively store the important bits of the imas structure in dicts.
@@ -117,11 +127,7 @@ class IDSMapping(Mapping):
             return
 
         # We made it here, the value can be stored
-        self.flat_fields['/'.join(path)] = val
-        cur = self.fields
-        for item in path[:-1]:
-            cur = cur[item]
-        cur[path[-1]] = val
+        self._keys.add('/'.join(path))
 
     def findall(self, pattern: str) -> Dict[str, Any]:
         """Find keys matching regex pattern.
@@ -140,10 +146,7 @@ class IDSMapping(Mapping):
 
         pat = re.compile(pattern)
 
-        return {
-            key: self.flat_fields[key]
-            for key in self.flat_fields if pat.match(key)
-        }
+        return {key: self[key] for key in self._keys if pat.match(key)}
 
     def find_by_group(self, pattern: str) -> Dict[Union[tuple, str], Any]:
         """Find keys matching regex pattern by group.
@@ -166,12 +169,12 @@ class IDSMapping(Mapping):
         pat = re.compile(pattern)
 
         new = {}
-        for key in self.flat_fields:
+        for key in self._keys:
             m = pat.match(key)
             if m:
                 groups = m.groups()
                 idx = groups[0] if len(groups) == 1 else groups
-                new[idx] = self.flat_fields[key]
+                new[idx] = self[key]
 
         return new
 
@@ -206,7 +209,7 @@ class IDSMapping(Mapping):
 
         new_dict: Dict[str, Dict[int, np.ndarray]] = defaultdict(dict)
 
-        for key in self.flat_fields:
+        for key in self._keys:
             m = pat.match(key)
 
             if m:
@@ -214,7 +217,7 @@ class IDSMapping(Mapping):
                 new_key = key[:si] + idx_str + key[sj:]
 
                 idx = int(m.group('idx'))
-                new_dict[new_key][idx] = self.flat_fields[key]
+                new_dict[new_key][idx] = self[key]
 
         return new_dict
 
@@ -279,7 +282,7 @@ class IDSMapping(Mapping):
             Numpy array with a column for the time step and each of the
             variables.
         """
-        points_per_var = len(self.flat_fields[f'{prefix}/0/{variables[0]}'])
+        points_per_var = len(self[f'{prefix}/0/{variables[0]}'])
 
         if not time_steps:
             n_time_steps = len(self[TIME_COL])
@@ -303,6 +306,6 @@ class IDSMapping(Mapping):
 
                 arr[i_begin:i_end, 0] = t
                 arr[i_begin:i_end, 1] = timestamps[t]
-                arr[i_begin:i_end, j + 2] = self.flat_fields[flat_variable]
+                arr[i_begin:i_end, j + 2] = self[flat_variable]
 
         return columns, arr

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -30,7 +30,7 @@ class IDSMapping(Mapping):
         self._ids = ids
         self.exclude_empty = exclude_empty
 
-        # All fields in the core profile in a single dict
+        # All available data fields are stored in this set.
         self._keys: Set[str] = set()
 
         self.dive(ids, [])
@@ -89,12 +89,17 @@ class IDSMapping(Mapping):
         """Synchronize updated data back to IMAS db entry.
 
         Shortcut for 'put' command.
+
+        Parameters
+        ----------
+        handle : ImasHandle
+            Points to an IMAS db entry of where the data should be written.
         """
         with handle.open() as f:
             self._ids.put(db_entry=f)
 
     def dive(self, val, path: list):
-        """Recursively store the important bits of the imas structure in dicts.
+        """Recursively find the data fields.
 
         Parameters
         ----------

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -43,10 +43,8 @@ class IDSMapping(Mapping):
 
         return s
 
-    def __getitem__(self, key: str):
-        if key not in self._keys:
-            raise KeyError(key)
-
+    def _deconstruct_key(self, key: str):
+        """Break down key and return pointer + attr."""
         *parts, attr = key.split('/')
 
         pointer = self._ids
@@ -58,6 +56,14 @@ class IDSMapping(Mapping):
                 pointer = getattr(pointer, part)
             else:
                 pointer = pointer[i]
+
+        return pointer, attr
+
+    def __getitem__(self, key: str):
+        if key not in self._keys:
+            raise KeyError(key)
+
+        pointer, attr = self._deconstruct_key(key)
 
         return getattr(pointer, attr)
 
@@ -65,17 +71,7 @@ class IDSMapping(Mapping):
         if key not in self._keys:
             return f'Cannot set non-existant key: {key}'
 
-        *parts, attr = key.split('/')
-
-        pointer = self._ids
-
-        for part in parts:
-            try:
-                i = int(part)
-            except ValueError:
-                pointer = getattr(pointer, part)
-            else:
-                pointer = pointer[i]
+        pointer, attr = self._deconstruct_key(key)
 
         setattr(pointer, attr, value)
 

--- a/tests/ids/test_mapping.py
+++ b/tests/ids/test_mapping.py
@@ -33,25 +33,23 @@ class Sample:
 def test_mapping():
     s = IDSMapping(Sample)
 
-    assert_equal(s.flat_fields['time'], np.array([1., 2., 3.]))
-    assert_equal(s.flat_fields['_h'], np.array([0, 0]))
-    assert_equal(s.flat_fields['data/0/x'], np.array([0, 1]))
-    assert_equal(s.flat_fields['data/0/y'], np.array([2, 3]))
-    assert_equal(s.flat_fields['data/1/x'], np.array([4, 5]))
-    assert_equal(s.flat_fields['data/1/y'], np.array([6, 7]))
-    assert_equal(s.flat_fields['data/2/x'], np.array([8, 9]))
-    assert_equal(s.flat_fields['data/2/y'], np.array([10, 11]))
+    assert_equal(s['time'], np.array([1., 2., 3.]))
+    assert_equal(s['_h'], np.array([0, 0]))
+    assert_equal(s['data/0/x'], np.array([0, 1]))
+    assert_equal(s['data/0/y'], np.array([2, 3]))
+    assert_equal(s['data/1/x'], np.array([4, 5]))
+    assert_equal(s['data/1/y'], np.array([6, 7]))
+    assert_equal(s['data/2/x'], np.array([8, 9]))
+    assert_equal(s['data/2/y'], np.array([10, 11]))
 
-    assert 'data/0/z' not in s.flat_fields
-    assert 'data/0/z' not in s.flat_fields
-
-    assert_equal(s.fields['data']['0']['x'], np.array([0, 1]))
+    assert 'data/0/z' not in s
+    assert 'data/0/z' not in s
 
 
 def test_mapping_unknown_key_fail():
     s = IDSMapping(Sample)
     with pytest.raises(KeyError):
-        s.fields['this key does not exist']
+        s['this key does not exist']
 
 
 def test_find_all():

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -38,7 +38,7 @@ def cmdline_workdir(tmp_path_factory):
 
 @pytest.mark.dependency()
 def test_example_create(cmdline_workdir):
-    cmd = 'duqtools create -c config.yaml --force -y'.split()
+    cmd = 'duqtools create -c config.yaml --force --yes'.split()
 
     with work_directory(cmdline_workdir):
         result = subprocess.run(cmd)
@@ -47,7 +47,7 @@ def test_example_create(cmdline_workdir):
 
 @pytest.mark.dependency(depends=['test_example_create'])
 def test_example_submit(cmdline_workdir):
-    cmd = 'duqtools submit -c config.yaml -y'.split()
+    cmd = 'duqtools submit -c config.yaml --yes'.split()
 
     with work_directory(cmdline_workdir):
         result = subprocess.run(cmd)
@@ -56,7 +56,7 @@ def test_example_submit(cmdline_workdir):
 
 @pytest.mark.dependency(depends=['test_example_create'])
 def test_example_status(cmdline_workdir):
-    cmd = 'duqtools status -c config.yaml -y'.split()
+    cmd = 'duqtools status -c config.yaml --yes'.split()
 
     with work_directory(cmdline_workdir):
         result = subprocess.run(cmd)
@@ -66,7 +66,7 @@ def test_example_status(cmdline_workdir):
 @pytest.mark.dependency(depends=['test_example_status'])
 @pytest.mark.skip(reason='Should be fixed')
 def test_example_plot(cmdline_workdir):
-    cmd = 'duqtools plot -c config.yaml -y'.split()
+    cmd = 'duqtools plot -c config.yaml --yes'.split()
 
     with work_directory(cmdline_workdir):
         result = subprocess.run(cmd)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -95,7 +95,7 @@ def test_plot(cmdline_workdir):
             'config.yaml',
             '--dry-run',
             '-x',
-            'grid//rho_tor_norm',
+            'grid/rho_tor_norm',
             '-y',
             't_i_average',
             '--imas',


### PR DESCRIPTION
This PR enables data to be set on the IDSMapping directly. We need this functionality so that we can overwrite empty arrays, i.e. `*_error_upper` in #156. I did this by deconstructing the key, and finding the corresponding array using `getattr`/`setattr`. This means the `.fields` key can no longer be used (we didn't use it anyway in the code).

It also means we don't have to rely on updating the numpy arrays in-place, like we do in the create step (`profile[:] = np.array([...])` or using the `out` argument).