### PR TITLE
Revise merge config

### DIFF
--- a/docs/gendocs.py
+++ b/docs/gendocs.py
@@ -74,11 +74,10 @@ if 'merge' in models:
     extra_schemas['wd_schema'] = cfg.workspace.schema()
     extra_yamls['wd_yaml'] = model2config('workspace', cfg.workspace)
 
-    from duqtools.jetto import JettoSystem
-    from duqtools.system import DummySystem
+    from duqtools.schema.cli import MergeStep
 
-    extra_schemas['jetto_schema'] = JettoSystem.schema()
-    extra_schemas['dummy_schema'] = DummySystem.schema()
+    extra_schemas['merge_op_schema'] = cfg.merge.plan.schema()
+    extra_yamls['merge_op_yaml'] = model2config('plan', MergeStep())
 
 for name, model in models.items():
     template = get_template(f'template_{name}.md')

--- a/docs/templates/template_merge.md
+++ b/docs/templates/template_merge.md
@@ -51,3 +51,38 @@ output:
 !!! note
 
     Although the user can be specified for the output location, it is best left blank. In this case, the current user is filled in automatically and you will not run into issues with write permissions.
+
+
+## Merge plan
+
+{{ merge_op_schema['description'] }}
+
+{% for name, prop in merge_op_schema['properties'].items() %}
+`{{ name }}`
+: {{ prop['description'] }}
+{% endfor %}
+
+For example:
+
+```yaml title="duqtools.yaml"
+template:
+  user: g2ssmee
+  db: jet
+  shot: 91234
+  run: 1
+output:
+  db: jet
+  shot: 91234
+  run: 100
+```
+
+For example:
+
+```yaml title="duqtools.yaml"
+plan:
+  - ids: core_profiles
+    base_grid: profiles_1d/*/grid/rho_tor_norm
+    paths:
+    - profiles_1d/*/t_i_average
+    - profiles_1d/*/zeff
+```

--- a/src/duqtools/ids/_io.py
+++ b/src/duqtools/ids/_io.py
@@ -11,16 +11,19 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-def _get_ids_run_dataframe(handle: ImasHandle, *, keys,
+def _get_ids_run_dataframe(handle: ImasHandle,
+                           *,
+                           ids: str = 'core_profiles',
+                           keys: Sequence[str],
                            **kwargs) -> pd.DataFrame:
     """Get data for single run."""
     logger.info('Getting data for %s', handle)
-    profile = handle.get('core_profiles', exclude_empty=True)
+    profile = handle.get(ids, exclude_empty=True)
     return profile.to_dataframe(*keys, **kwargs)
 
 
 def get_ids_dataframe(handles: Union[Sequence[ImasHandle],
-                                     Dict[str, ImasHandle]], *,
+                                     Dict[str, ImasHandle]], *, ids: str,
                       keys: Sequence[str], **kwargs) -> pd.DataFrame:
     """Read a dict of IMAS handles into a structured pandas dataframe.
 
@@ -37,8 +40,10 @@ def get_ids_dataframe(handles: Union[Sequence[ImasHandle],
         Dict with IMAS handles. The key is used as the 'run' name in
         the dataframe. If the handles are specified as a sequence,
         The Imas string representation will be used as the key.
+    ids : str
+        IDS to extract data from (e.g. `'core_profiles'`).
     keys : Sequence[str]
-        IDS values to extract. These will be used as columns in the
+        IDS keys to extract. These will be used as columns in the
         data frame.
     **kwargs
         These keyword parameters are passed to
@@ -55,7 +60,7 @@ def get_ids_dataframe(handles: Union[Sequence[ImasHandle],
         handles = {handle.to_string(): handle for handle in handles}
 
     runs_data = {
-        str(name): _get_ids_run_dataframe(handle, keys=keys, **kwargs)
+        str(name): _get_ids_run_dataframe(handle, ids=ids, keys=keys, **kwargs)
         for name, handle in handles.items()
     }
 

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -8,13 +8,14 @@ from ._handle import ImasHandle
 from ._rebase import rebase_on_grid, rebase_on_time
 
 
-@add_to_op_queue('Merge data to', '{target}')
+@add_to_op_queue('Merge', '{ids} -> {target}')
 def merge_data(data: pd.DataFrame,
                target: ImasHandle,
                x_val: str,
                y_vals: Sequence[str],
+               ids: str = 'core_profiles',
                prefix: str = 'profiles_1d'):
-    input_data = target.get('core_profiles')
+    input_data = target.get(ids)
 
     # pick first time step as basis
     common_basis = input_data[f'{prefix}/0/{x_val}']
@@ -36,7 +37,7 @@ def merge_data(data: pd.DataFrame,
 
     merged = gb.agg(agg_dict)
 
-    ids_mapping = target.get('core_profiles', exclude_empty=False)
+    ids_mapping = target.get(ids, exclude_empty=False)
 
     for y_val in y_vals:
         for tstep, group in merged.groupby('tstep'):

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -69,4 +69,5 @@ def merge(**kwargs):
                    target=target,
                    x_val=x_val,
                    y_vals=y_vals,
-                   prefix=prefix)
+                   prefix=prefix,
+                   ids=step.ids)

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Sequence, Tuple
 
 from .config import cfg
 from .ids import ImasHandle, get_ids_dataframe, merge_data
@@ -12,6 +13,33 @@ logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
+def _split_paths(paths: Sequence[str]) -> Tuple[str, Tuple[str, ...]]:
+    """Split paths into its common prefix and keys.
+
+    Parameters
+    ----------
+    paths : Sequence[str]
+        Paths that can be found in the IDS entry. Must contain
+        `/*/` to denote the time component.
+
+    Returns
+    -------
+    prefix, keys : Tuple[str, List[str]]
+        Return the common prefix and corresponding keys.
+    """
+
+    split_paths = (path.split('/*/') for path in paths)
+
+    prefixes, keys = zip(*split_paths)
+
+    prefix_set = set(prefixes)
+    if not len(prefix_set) == 1:
+        raise ValueError(
+            f'All keys must have the same prefix, got {prefix_set}')
+
+    return prefixes[0], keys
+
+
 @confirm_operations
 def merge(**kwargs):
     """Merge data."""
@@ -21,21 +49,24 @@ def merge(**kwargs):
     template = ImasHandle.parse_obj(cfg.merge.template)
     target = ImasHandle.parse_obj(cfg.merge.output)
 
-    prefix = cfg.merge.prefix
-    x_val = cfg.merge.base_ids
-    y_vals = cfg.merge.ids_to_merge
+    for step in cfg.merge.plan:
+        prefix, (x_val, *y_vals) = _split_paths(paths=(step.base_grid,
+                                                       *step.paths))
 
-    handles = read_imas_handles_from_file(workspace.runs_yaml)
+        handles = read_imas_handles_from_file(workspace.runs_yaml)
 
-    data = get_ids_dataframe(handles, keys=(x_val, *y_vals), prefix=prefix)
+        data = get_ids_dataframe(handles,
+                                 ids=step.ids,
+                                 keys=(x_val, *y_vals),
+                                 prefix=prefix)
 
-    debug('Merge input: %s', template)
-    debug('Merge output: %s', target)
+        debug('Merge input: %s', template)
+        debug('Merge output: %s', target)
 
-    template.copy_data_to(target)
+        template.copy_data_to(target)
 
-    merge_data(data=data,
-               target=target,
-               x_val=x_val,
-               y_vals=y_vals,
-               prefix=cfg.merge.prefix)
+        merge_data(data=data,
+                   target=target,
+                   x_val=x_val,
+                   y_vals=y_vals,
+                   prefix=prefix)

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -5,7 +5,6 @@ from typing import Sequence, Tuple
 
 from .config import cfg
 from .ids import ImasHandle, get_ids_dataframe, merge_data
-from .models import WorkDirectory
 from .operations import confirm_operations
 from .utils import read_imas_handles_from_file
 
@@ -43,17 +42,14 @@ def _split_paths(paths: Sequence[str]) -> Tuple[str, Tuple[str, ...]]:
 @confirm_operations
 def merge(**kwargs):
     """Merge data."""
-
-    workspace = WorkDirectory.parse_obj(cfg.workspace)
-
     template = ImasHandle.parse_obj(cfg.merge.template)
     target = ImasHandle.parse_obj(cfg.merge.output)
+
+    handles = read_imas_handles_from_file(cfg.merge.data)
 
     for step in cfg.merge.plan:
         prefix, (x_val, *y_vals) = _split_paths(paths=(step.base_grid,
                                                        *step.paths))
-
-        handles = read_imas_handles_from_file(workspace.runs_yaml)
 
         data = get_ids_dataframe(handles,
                                  ids=step.ids,

--- a/src/duqtools/plot.py
+++ b/src/duqtools/plot.py
@@ -28,7 +28,9 @@ def plot(*, x_val, y_vals, imas_paths, input_files, dry_run, extensions,
     if len(handles) == 0:
         raise SystemExit('No data to show.')
 
-    source = get_ids_dataframe(handles, keys=(x_val, *y_vals))
+    source = get_ids_dataframe(handles,
+                               ids='core_profiles',
+                               keys=(x_val, *y_vals))
 
     click.echo('You can now view your plot in your browser:')
     click.echo('')

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -141,7 +141,21 @@ class StatusConfigModel(BaseModel):
             """))
 
 
-class MergeOp(BaseModel):
+class MergeStep(BaseModel):
+    """These parameters describe which paths should be merged.
+
+    The IDS parameter (`ids`) describes the where the data are retrieved from.
+    This IDS then contains the given `paths`, which belong to this IDS.
+
+    The base grid points to the data which should be used as the common basis. All
+    other data arrays are interpolated to this grid. Both the template and the
+    data must contain this data.
+
+    To denote the time step, use `/*/` in both the base grid and the data paths.
+
+    Note that multiple merge steps can be specified, for example for different
+    IDS.
+    """
     ids: str = Field('core_profiles',
                      description='Merge fields from this IDS.')
     paths: List[str] = Field(
@@ -149,13 +163,14 @@ class MergeOp(BaseModel):
         description=f("""
             This is a list of IDS paths to merge over all runs.
             The mean/error are written to the target IDS.
-            The patsh must have `/*/` for the time component.
+            The paths should contain `/*/` for the time component.
         """))
     base_grid: str = Field('profiles_1d/*/grid/rho_tor_norm',
                            description=f("""
-            This IDS field is taken from the template. It is used to rebase all IDS fields
-            to same radial grid before merging using an interpolation. Must contain
-            '/*/' for the time component.
+            The data for this field is taken from the template. The IMAS data to merge should
+            also contain this path, because it will be used to rebase all IDS fields
+            to same radial grid before merging using interpolation. The path should contain
+            '/*/' to denote the time component.
             """))
 
 
@@ -163,8 +178,10 @@ class MergeConfigModel(BaseModel):
     """The options of the `merge` subcommand are stored under the `merge` key
     in the config.
 
-    These keys define which data to merge, and where to store the
-    output. Before merging, all keys are rebased on (1) the same radial
+    These keys define the location of the IMAS data, which IDS entries
+    to merge, and where to store the output.
+
+    Before merging, all keys are rebased on (1) the same radial
     coordinate specified via `base_ids` and (2) the timestamp.
     """
     data: FilePath = Field('runs.yaml',
@@ -186,8 +203,8 @@ class MergeConfigModel(BaseModel):
             'run': 9999
         },
         description='Merged data will be written to this IMAS DB entry.')
-    plan: List[MergeOp] = Field(MergeOp(),
-                                description='List of merging operations.')
+    plan: List[MergeStep] = Field(MergeStep(),
+                                  description='List of merging operations.')
 
 
 class ConfigModel(BaseModel):

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -141,6 +141,24 @@ class StatusConfigModel(BaseModel):
             """))
 
 
+class MergeOp(BaseModel):
+    ids: str = Field('core_profiles',
+                     description='Merge fields from this IDS.')
+    paths: List[str] = Field(
+        ['profiles_1d/*/t_i_average', 'profiles_1d/*/zeff'],
+        description=f("""
+            This is a list of IDS paths to merge over all runs.
+            The mean/error are written to the target IDS.
+            The patsh must have `/*/` for the time component.
+        """))
+    base_grid: str = Field('profiles_1d/*/grid/rho_tor_norm',
+                           description=f("""
+            This IDS field is taken from the template. It is used to rebase all IDS fields
+            to same radial grid before merging using an interpolation. Must contain
+            '/*/' for the time component.
+            """))
+
+
 class MergeConfigModel(BaseModel):
     """The options of the `merge` subcommand are stored under the `merge` key
     in the config.
@@ -164,21 +182,8 @@ class MergeConfigModel(BaseModel):
             'run': 9999
         },
         description='Merged data will be written to this IMAS DB entry.')
-    ids_to_merge: List[str] = Field(['t_i_average', 'zeff'],
-                                    description=f("""
-            This is a list of IDSs to merge over all runs together with the `prefix`.
-            The mean/error are written to the target IDS.
-        """))
-    base_ids: str = Field('grid/rho_tor_norm',
-                          description=f("""
-            This IDS field is taken from the template. It is used to rebase all IDS fields
-            to same radial grid before merging using an interpolation.
-            """))
-    prefix: str = Field('profiles_1d',
-                        description=f("""
-            This field specifies the prefix to the IDS path, i.e.
-            `<prefix>/<time_step>/<ids_to_merge>'. The time step is implied by the template.
-            """))
+    plan: List[MergeOp] = Field(MergeOp(),
+                                description='List of merging operations.')
 
 
 class ConfigModel(BaseModel):

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -1,7 +1,7 @@
 from getpass import getuser
 from typing import List, Union
 
-from pydantic import DirectoryPath, Field, validator
+from pydantic import DirectoryPath, Field, FilePath, validator
 from typing_extensions import Literal
 
 from ._basemodel import BaseModel
@@ -167,6 +167,10 @@ class MergeConfigModel(BaseModel):
     output. Before merging, all keys are rebased on (1) the same radial
     coordinate specified via `base_ids` and (2) the timestamp.
     """
+    data: FilePath = Field('runs.yaml',
+                           description=f("""
+            Data file with IMAS handles, such as `data.csv` or `runs.yaml`'
+        """))
     template: ImasBaseModel = Field(
         {
             'user': getuser(),


### PR DESCRIPTION
This PR revises the merge config. It removes the 'prefix' and enables multiple merge steps to be included.

It also prepares for specifying the IDS in the config (currently we assume 'core_profiles' in many places).

Closes #218 