### PR TITLE
Add implementation for xarray as in-memory data format

### DIFF
--- a/scripts/data_for_testing.py
+++ b/scripts/data_for_testing.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+
+class nested_val:
+    val = np.array([123])
+
+
+class profile_t0:
+    grid = np.arange(10) * 1
+    variable = grid**2
+    val = 1
+
+
+class profile_t1:
+    grid = np.arange(10) * 2
+    variable = grid**2
+    val = 2
+
+
+class profile_t2:
+    grid = np.arange(10) * 3
+    variable = grid**2
+    val = 3
+
+
+class nested_profile_t0:
+    data = profile_t0
+
+
+class nested_profile_t1:
+    data = profile_t1
+
+
+class nested_profile_t2:
+    data = profile_t2
+
+
+class arr_t0:
+    grid = np.arange(25).reshape(5, 5) * 1
+    variable = grid**1
+
+
+class arr_t1:
+    grid = np.arange(25).reshape(5, 5) * 2
+    variable = grid**2
+
+
+class arr_t2:
+    grid = np.arange(25).reshape(5, 5) * 3
+    variable = grid**3
+
+
+class nested_arr_t0:
+    data = arr_t0
+
+
+class nested_arr_t1:
+    data = arr_t1
+
+
+class nested_arr_t2:
+    data = arr_t2
+
+
+class Sample:
+    profiles_1d = [profile_t0, profile_t1, profile_t2]
+    nested_profiles_1d = [
+        nested_profile_t0, nested_profile_t1, nested_profile_t2
+    ]
+
+    profiles_2d = [arr_t0, arr_t1, arr_t2]
+    nested_profiles_2d = [nested_arr_t0, nested_arr_t1, nested_arr_t2]
+
+    single_val = np.array([123])
+    nested_single_val = nested_val
+
+    single_profile_1d = profile_t0
+    nested_single_profile_1d = nested_profile_t0
+
+    single_profile_2d = arr_t0
+    nested_single_profile_2d = nested_arr_t0
+
+    time = np.array((23, 24, 25))

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     altair
     click
     f90nml
+    gitpython
     # https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     importlib_resources
     numpy
@@ -53,10 +54,10 @@ install_requires =
     pydantic-yaml
     ruamel.yaml
     scipy
+    setuptools
     tqdm
     typing-extensions
-    gitpython
-    setuptools
+    xarray
 
 [options.extras_require]
 develop =

--- a/src/duqtools/api.py
+++ b/src/duqtools/api.py
@@ -10,6 +10,7 @@ Data classes:
 
 - [ImasHandle][duqtools.api.ImasHandle]
 - [IDSMapping][duqtools.api.IDSMapping]
+- [Variable][duqtools.api.Variable]
 
 Plotting:
 
@@ -18,8 +19,8 @@ Plotting:
 """
 
 from ._plot_utils import alt_errorband_chart, alt_line_chart
-from .ids import (IDSMapping, ImasHandle, get_ids_dataframe, rebase_on_grid,
-                  rebase_on_time)
+from .ids import (IDSMapping, ImasHandle, Variable, get_ids_dataframe,
+                  rebase_on_grid, rebase_on_time)
 
 __all__ = [
     'get_ids_dataframe',
@@ -27,6 +28,7 @@ __all__ = [
     'rebase_on_time',
     'ImasHandle',
     'IDSMapping',
+    'Variable',
     'alt_line_chart',
     'alt_errorband_chart',
 ]

--- a/src/duqtools/ids/__init__.py
+++ b/src/duqtools/ids/__init__.py
@@ -6,6 +6,7 @@ from ._io import get_ids_dataframe
 from ._mapping import IDSMapping
 from ._merge import merge_data
 from ._rebase import rebase_on_grid, rebase_on_time
+from ._variable import Variable
 
 logger = logging.getLogger(__name__)
 
@@ -17,4 +18,5 @@ __all__ = [
     'merge_data',
     'rebase_on_grid',
     'rebase_on_time',
+    'Variable',
 ]

--- a/src/duqtools/ids/_io.py
+++ b/src/duqtools/ids/_io.py
@@ -18,8 +18,8 @@ def _get_ids_run_dataframe(handle: ImasHandle,
                            **kwargs) -> pd.DataFrame:
     """Get data for single run."""
     logger.info('Getting data for %s', handle)
-    profile = handle.get(ids, exclude_empty=True)
-    return profile.to_dataframe(*keys, **kwargs)
+    data = handle.get(ids, exclude_empty=True)
+    return data.to_dataframe(*keys, **kwargs)
 
 
 def get_ids_dataframe(handles: Union[Sequence[ImasHandle],

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -325,8 +325,8 @@ class IDSMapping(Mapping):
 
     def to_xarray(
         self,
-        data_vars: Sequence[Variable],
-        coord_vars: Sequence[Variable],
+        data_vars: Sequence[Variable] = None,
+        coord_vars: Sequence[Variable] = None,
     ) -> xr.Dataset:
         """Return dataset for given variables.
 
@@ -344,6 +344,11 @@ class IDSMapping(Mapping):
         """
         import xarray as xr
 
+        if not coord_vars:
+            coord_vars = ()
+        if not data_vars:
+            data_vars = ()
+
         xr_coords = {}
         xr_data_vars = {}
 
@@ -352,6 +357,10 @@ class IDSMapping(Mapping):
 
         for var in data_vars:
             dimensions = DIM_PATTERN.findall(var.path)
+            if not dimensions:
+                xr_data_vars[var.name] = (var.dims, self[var.path])
+                continue
+
             if len(dimensions) > 1:
                 raise NotImplementedError
 

--- a/src/duqtools/ids/_variable.py
+++ b/src/duqtools/ids/_variable.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class Variable(BaseModel):
+    """Variable for describing data within a IMAS database."""
+    name: str
+    ids: str
+    path: str
+    dims: List[str]

--- a/tests/ids/idsmapping_sample_data.py
+++ b/tests/ids/idsmapping_sample_data.py
@@ -1,0 +1,83 @@
+import numpy as np
+
+
+class nested_val:
+    val = np.array([123])
+
+
+class profile_t0:
+    grid = np.arange(10) * 1
+    variable = grid**2
+    val = 1
+
+
+class profile_t1:
+    grid = np.arange(10) * 2
+    variable = grid**2
+    val = 2
+
+
+class profile_t2:
+    grid = np.arange(10) * 3
+    variable = grid**2
+    val = 3
+
+
+class nested_profile_t0:
+    data = profile_t0
+
+
+class nested_profile_t1:
+    data = profile_t1
+
+
+class nested_profile_t2:
+    data = profile_t2
+
+
+class arr_t0:
+    grid = np.arange(25).reshape(5, 5) * 1
+    variable = grid**1
+
+
+class arr_t1:
+    grid = np.arange(25).reshape(5, 5) * 2
+    variable = grid**2
+
+
+class arr_t2:
+    grid = np.arange(25).reshape(5, 5) * 3
+    variable = grid**3
+
+
+class nested_arr_t0:
+    data = arr_t0
+
+
+class nested_arr_t1:
+    data = arr_t1
+
+
+class nested_arr_t2:
+    data = arr_t2
+
+
+class Sample:
+    profiles_1d = [profile_t0, profile_t1, profile_t2]
+    nested_profiles_1d = [
+        nested_profile_t0, nested_profile_t1, nested_profile_t2
+    ]
+
+    profiles_2d = [arr_t0, arr_t1, arr_t2]
+    nested_profiles_2d = [nested_arr_t0, nested_arr_t1, nested_arr_t2]
+
+    single_val = np.array([123])
+    nested_single_val = nested_val
+
+    single_profile_1d = profile_t0
+    nested_single_profile_1d = nested_profile_t0
+
+    single_profile_2d = arr_t0
+    nested_single_profile_2d = nested_arr_t0
+
+    time = np.array((23, 24, 25))

--- a/tests/ids/test_xarray_interface.py
+++ b/tests/ids/test_xarray_interface.py
@@ -13,6 +13,54 @@ TIME_VAR = Variable(
 
 
 @pytest.fixture
+def expected_dataset_no_index():
+    return xr.Dataset.from_dict({
+        'coords': {
+            'time': {
+                'dims': ('time', ),
+                'attrs': {},
+                'data': [23, 24, 25]
+            }
+        },
+        'attrs': {},
+        'dims': {
+            'x': 10,
+            'time': 3
+        },
+        'data_vars': {
+            'xvar': {
+                'dims': ('x', ),
+                'attrs': {},
+                'data': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+            },
+            'yvar': {
+                'dims': ('x', ),
+                'attrs': {},
+                'data': [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+            }
+        }
+    })
+
+
+@pytest.fixture
+def expected_dataset_0d():
+    return xr.Dataset.from_dict({
+        'coords': {},
+        'attrs': {},
+        'dims': {
+            'x': 1
+        },
+        'data_vars': {
+            'xval': {
+                'dims': ('x', ),
+                'attrs': {},
+                'data': [123]
+            }
+        }
+    })
+
+
+@pytest.fixture
 def expected_dataset_1d():
     return xr.Dataset.from_dict({
         'coords': {
@@ -126,6 +174,42 @@ def sample_data():
     return IDSMapping(Sample)
 
 
+def test_no_time_index(sample_data, expected_dataset_no_index):
+    coord_vars = [TIME_VAR]
+
+    data_vars = [
+        Variable(
+            name='xvar',
+            ids='core_profiles',
+            path='nested_single_profile_1d/data/grid',
+            dims=['x'],
+        ),
+        Variable(
+            name='yvar',
+            ids='core_profiles',
+            path='nested_single_profile_1d/data/variable',
+            dims=['x'],
+        ),
+    ]
+
+    dataset = sample_data.to_xarray(data_vars=data_vars, coord_vars=coord_vars)
+    xr.testing.assert_equal(dataset, expected_dataset_no_index)
+
+
+def test_0d(sample_data, expected_dataset_0d):
+    data_vars = [
+        Variable(
+            name='xval',
+            ids='core_profiles',
+            path='nested_single_val/val',
+            dims=['x'],
+        ),
+    ]
+    dataset = sample_data.to_xarray(data_vars=data_vars, coord_vars=None)
+
+    xr.testing.assert_equal(dataset, expected_dataset_0d)
+
+
 def test_1d(sample_data, expected_dataset_1d):
     coord_vars = [TIME_VAR]
 
@@ -144,9 +228,8 @@ def test_1d(sample_data, expected_dataset_1d):
         ),
     ]
 
-    dataset_1d = sample_data.to_xarray(data_vars=data_vars,
-                                       coord_vars=coord_vars)
-    xr.testing.assert_equal(dataset_1d, expected_dataset_1d)
+    dataset = sample_data.to_xarray(data_vars=data_vars, coord_vars=coord_vars)
+    xr.testing.assert_equal(dataset, expected_dataset_1d)
 
 
 def test_2d(sample_data, expected_dataset_2d):
@@ -167,6 +250,5 @@ def test_2d(sample_data, expected_dataset_2d):
         ),
     ]
 
-    dataset_2d = sample_data.to_xarray(data_vars=data_vars,
-                                       coord_vars=coord_vars)
-    xr.testing.assert_equal(dataset_2d, expected_dataset_2d)
+    dataset = sample_data.to_xarray(data_vars=data_vars, coord_vars=coord_vars)
+    xr.testing.assert_equal(dataset, expected_dataset_2d)

--- a/tests/ids/test_xarray_interface.py
+++ b/tests/ids/test_xarray_interface.py
@@ -1,0 +1,145 @@
+import pytest
+import xarray as xr
+from idsmapping_sample_data import Sample
+
+from duqtools.api import IDSMapping
+
+
+@pytest.fixture
+def expected_dataset_1d():
+    return xr.Dataset.from_dict({
+        'coords': {
+            'time': {
+                'dims': ('time', ),
+                'attrs': {},
+                'data': [23, 24, 25]
+            }
+        },
+        'attrs': {},
+        'dims': {
+            'time': 3,
+            'x': 10
+        },
+        'data_vars': {
+            'xvar': {
+                'dims': ('time', 'x'),
+                'attrs': {},
+                'data': [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                         [0, 2, 4, 6, 8, 10, 12, 14, 16, 18],
+                         [0, 3, 6, 9, 12, 15, 18, 21, 24, 27]]
+            },
+            'yvar': {
+                'dims': ('time', 'x'),
+                'attrs': {},
+                'data': [[0, 1, 4, 9, 16, 25, 36, 49, 64, 81],
+                         [0, 4, 16, 36, 64, 100, 144, 196, 256, 324],
+                         [0, 9, 36, 81, 144, 225, 324, 441, 576, 729]]
+            }
+        }
+    })
+
+
+@pytest.fixture
+def expected_dataset_2d():
+    return xr.Dataset.from_dict({
+        'coords': {
+            'time': {
+                'dims': ('time', ),
+                'attrs': {},
+                'data': [23, 24, 25]
+            }
+        },
+        'attrs': {},
+        'dims': {
+            'time': 3,
+            'x': 5,
+            'y': 5
+        },
+        'data_vars': {
+            'xvar': {
+                'dims': ('time', 'x', 'y'),
+                'attrs': {},
+                'data': [
+                    [
+                        [0, 1, 2, 3, 4],
+                        [5, 6, 7, 8, 9],
+                        [10, 11, 12, 13, 14],
+                        [15, 16, 17, 18, 19],
+                        [20, 21, 22, 23, 24],
+                    ],
+                    [
+                        [0, 2, 4, 6, 8],
+                        [10, 12, 14, 16, 18],
+                        [20, 22, 24, 26, 28],
+                        [30, 32, 34, 36, 38],
+                        [40, 42, 44, 46, 48],
+                    ],
+                    [
+                        [0, 3, 6, 9, 12],
+                        [15, 18, 21, 24, 27],
+                        [30, 33, 36, 39, 42],
+                        [45, 48, 51, 54, 57],
+                        [60, 63, 66, 69, 72],
+                    ],
+                ]
+            },
+            'yvar': {
+                'dims': ('time', 'x', 'y'),
+                'attrs': {},
+                'data': [
+                    [
+                        [0, 1, 2, 3, 4],
+                        [5, 6, 7, 8, 9],
+                        [10, 11, 12, 13, 14],
+                        [15, 16, 17, 18, 19],
+                        [20, 21, 22, 23, 24],
+                    ],
+                    [
+                        [0, 4, 16, 36, 64],
+                        [100, 144, 196, 256, 324],
+                        [400, 484, 576, 676, 784],
+                        [900, 1024, 1156, 1296, 1444],
+                        [1600, 1764, 1936, 2116, 2304],
+                    ],
+                    [
+                        [0, 27, 216, 729, 1728],
+                        [3375, 5832, 9261, 13824, 19683],
+                        [27000, 35937, 46656, 59319, 74088],
+                        [91125, 110592, 132651, 157464, 185193],
+                        [216000, 250047, 287496, 328509, 373248],
+                    ],
+                ]
+            }
+        }
+    })
+
+
+@pytest.fixture
+def sample_data():
+    return IDSMapping(Sample)
+
+
+def test_1d(sample_data, expected_dataset_1d):
+    coord_patterns = {'time': 'time'}
+
+    data_patterns = {
+        'xvar': 'nested_profiles_1d/$time/data/grid',
+        'yvar': 'nested_profiles_1d/$time/data/variable',
+    }
+
+    dataset_1d = sample_data.to_xarray(data_vars=data_patterns,
+                                       coord_vars=coord_patterns)
+    xr.testing.assert_equal(dataset_1d, expected_dataset_1d)
+
+
+def test_2d(sample_data, expected_dataset_2d):
+    coord_patterns = {'time': 'time'}
+
+    data_patterns = {
+        'xvar': 'nested_profiles_2d/$time/data/grid',
+        'yvar': 'nested_profiles_2d/$time/data/variable',
+    }
+
+    dataset_2d = sample_data.to_xarray(data_vars=data_patterns,
+                                       coord_vars=coord_patterns)
+    xr.testing.assert_equal(dataset_2d, expected_dataset_2d)

--- a/tests/ids/test_xarray_interface.py
+++ b/tests/ids/test_xarray_interface.py
@@ -2,7 +2,14 @@ import pytest
 import xarray as xr
 from idsmapping_sample_data import Sample
 
-from duqtools.api import IDSMapping
+from duqtools.api import IDSMapping, Variable
+
+TIME_VAR = Variable(
+    name='time',
+    ids='core_profiles',
+    path='time',
+    dims=['time'],
+)
 
 
 @pytest.fixture
@@ -120,26 +127,46 @@ def sample_data():
 
 
 def test_1d(sample_data, expected_dataset_1d):
-    coord_patterns = {'time': 'time'}
+    coord_vars = [TIME_VAR]
 
-    data_patterns = {
-        'xvar': 'nested_profiles_1d/$time/data/grid',
-        'yvar': 'nested_profiles_1d/$time/data/variable',
-    }
+    data_vars = [
+        Variable(
+            name='xvar',
+            ids='core_profiles',
+            path='nested_profiles_1d/$time/data/grid',
+            dims=['x'],
+        ),
+        Variable(
+            name='yvar',
+            ids='core_profiles',
+            path='nested_profiles_1d/$time/data/variable',
+            dims=['x'],
+        ),
+    ]
 
-    dataset_1d = sample_data.to_xarray(data_vars=data_patterns,
-                                       coord_vars=coord_patterns)
+    dataset_1d = sample_data.to_xarray(data_vars=data_vars,
+                                       coord_vars=coord_vars)
     xr.testing.assert_equal(dataset_1d, expected_dataset_1d)
 
 
 def test_2d(sample_data, expected_dataset_2d):
-    coord_patterns = {'time': 'time'}
+    coord_vars = [TIME_VAR]
 
-    data_patterns = {
-        'xvar': 'nested_profiles_2d/$time/data/grid',
-        'yvar': 'nested_profiles_2d/$time/data/variable',
-    }
+    data_vars = [
+        Variable(
+            name='xvar',
+            ids='core_profiles',
+            path='nested_profiles_2d/$time/data/grid',
+            dims=['x', 'y'],
+        ),
+        Variable(
+            name='yvar',
+            ids='core_profiles',
+            path='nested_profiles_2d/$time/data/variable',
+            dims=['x', 'y'],
+        ),
+    ]
 
-    dataset_2d = sample_data.to_xarray(data_vars=data_patterns,
-                                       coord_vars=coord_patterns)
+    dataset_2d = sample_data.to_xarray(data_vars=data_vars,
+                                       coord_vars=coord_vars)
     xr.testing.assert_equal(dataset_2d, expected_dataset_2d)


### PR DESCRIPTION
In this PR I'm trying out to see how we can use xarray to store the data in memory. Pandas will not work well with 2D arrays, and xarray supports n-dimensional data. I have implemented a method `IDSMapping.to_xarray` that takes 2 sets of variables and returns an `xarray.Dataset`.

A useful feature is that any dataset can be converted into a dataframe with the same structure of what we currently use for rebasing / plotting.

Addresses #216 