### PR TITLE
Move variables out of `duqtools.yaml` to central config location

### DIFF
--- a/src/duqtools/data/variables.yaml
+++ b/src/duqtools/data/variables.yaml
@@ -1,0 +1,40 @@
+variables:
+- dims:
+  - time
+  - x
+  ids: core_profiles
+  name: rho_tor_norm
+  path: profiles_1d/*/grid/rho_tor_norm
+  type: IDS-variable
+- dims:
+  - time
+  - x
+  ids: core_profiles
+  name: t_i_average
+  path: profiles_1d/*/t_i_average
+  type: IDS-variable
+- dims:
+  - time
+  - x
+  ids: core_profiles
+  name: zeff
+  path: profiles_1d/*/zeff
+  type: IDS-variable
+- dims:
+  - time
+  ids: core_profiles
+  name: time
+  path: time
+  type: IDS-variable
+- lookup:
+    doc: Reference major radius (R0)
+    keys:
+    - field: EquilEscoRefPanel.refMajorRadius
+      file: jetto.jset
+    - field: RMJ
+      file: jetto.in
+      section: NLIST1
+    name: major_radius
+    type: float
+  name: major_radius
+  type: jetto-variable

--- a/src/duqtools/variables.py
+++ b/src/duqtools/variables.py
@@ -1,0 +1,65 @@
+import os
+from pathlib import Path
+
+from importlib_resources import files
+
+VAR_ENV = 'DUQTOOLS_VARDEF'
+USER_CONFIG_HOME = Path.home() / '.config'
+LOCAL_DIR = Path('.').absolute()
+DUQTOOLS_DIR = 'duqtools'
+VAR_FILENAME = 'variables.yaml'
+
+
+class VarConfig:
+
+    def __init__(self):
+
+        config_file = self.get_config_file()
+        if not config_file.exists():
+            raise IOError(f'{config_file} does not exist!')
+
+        self.config_file = config_file
+
+    def get_config_file(self) -> Path:
+        """Try to get the config file with variable definitions.
+
+        Search order:
+        1. environment variable
+        (2. local directory, not sure if this should be implemented)
+        3. config home (first $XDG_CONFIG_HOME/duqtools then `$HOME/.config/duqtools`)
+        4. fall back to variable definitions in package
+        """
+        for path in (
+                self._get_path_from_environment_variable(),
+                self._get_path_from_config_home(),
+                self._get_path_local_directory(),
+        ):
+            if path:
+                return path
+
+        return self._get_path_fallback()
+
+    def _get_path_from_environment_variable(self):
+        env = os.environ.get(VAR_ENV)
+        if env:
+            test_path = Path(env)
+            if not test_path.exists():
+                raise IOError(
+                    f'{test_path} defined by ${VAR_ENV} does not exist!')
+            return test_path
+
+    def _get_path_local_directory(self):
+        return None  # Not implemented
+
+    def _get_path_from_config_home(self):
+        config_home = os.environ.get('XDG_CONFIG_HOME', USER_CONFIG_HOME)
+
+        test_path = config_home / DUQTOOLS_DIR / VAR_FILENAME
+        if test_path.exists():
+            return test_path
+
+    def _get_path_fallback(self):
+        return files('duqtools.data') / VAR_FILENAME
+
+
+var_config = VarConfig()


### PR DESCRIPTION
This PR moves the variables definition outside the `duqtools.yaml` so they can be defined globally. Thi config can be defined in multiple places:

1. via environment variable `$DUQTOOLS_VARIABLES`,
2. If not defined, look for `$XDG_USER_HOME/duqtools/variables.yaml`
3. If XDG_USER_HOME is not defined, look for `$HOME/.config/duqtools/variables.yaml`
4. If not defined, fall back to `https://github.com/CarbonCollective/fusion-dUQtools/tree/main/src/duqtools/data/variables.yaml`, which will contain a sensible list of defaults.