### PR TITLE
Copy pre-defined config file when duqtools init is called

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -148,9 +148,6 @@ def cli(**kwargs):
 
 
 @cli.command('init')
-@click.option('--full',
-              is_flag=True,
-              help='Create a config file with all possible config values.')
 @click.option('--force', is_flag=True, help='Overwrite existing config.')
 @common_options
 def cli_init(**kwargs):

--- a/src/duqtools/data/duqtools.yaml
+++ b/src/duqtools/data/duqtools.yaml
@@ -1,0 +1,53 @@
+workspace:
+  root: /pfs/work/$USER/jetto/runs/
+system: jetto
+quiet: false
+create:
+  template: /pfs/work/$USER/jetto/runs/duqtools_template
+  data:
+    imasdb: test
+    run_in_start_at: 7000
+    run_out_start_at: 8000
+  dimensions:
+  - operator: multiply
+    scale_to_error: false
+    values: [1.1, 1.2, 1.3]
+    variable: t_i_average
+  - operator: multiply
+    scale_to_error: false
+    values: [1.1, 1.2, 1.3]
+    variable: zeff
+  - operator: copyto
+    scale_to_error: false
+    values: [296.0, 297.0]
+    variable: major_radius
+  sampler:
+    method: latin-hypercube
+    n_samples: 3
+merge:
+  data: runs.yaml
+  template:
+    db: jet
+    run: 1
+    shot: 94785
+    user: docs
+  output:
+    db: jet
+    run: 9999
+    shot: 94785
+  plan:
+  - data_variables:
+    - t_i_average
+    - zeff
+    grid_variable: rho_tor_norm
+    time_variable: time
+status:
+  in_file: jetto.in
+  msg_completed: 'Status : Completed successfully'
+  msg_failed: 'Status : Failed'
+  msg_running: 'Status : Running'
+  out_file: jetto.out
+  status_file: jetto.status
+submit:
+  submit_command: sbatch
+  submit_script_name: .llcmd

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -51,7 +51,7 @@ def test_clean_database(cmdline_workdir):
 
 def test_init(cmdline_workdir):
     with work_directory(cmdline_workdir):
-        cli_init(['--full', '--dry-run'], standalone_mode=False)
+        cli_init(['--dry-run'], standalone_mode=False)
         assert (not Path('./duqtools.yaml').exists())
 
 


### PR DESCRIPTION
This PR adds a pre-defined config file to the data directory. `duqtools init` copies this directory to the local directory.

Addresses #311 