### PR TITLE
Remove defaults that are too specific

### DIFF
--- a/src/duqtools/config/__init__.py
+++ b/src/duqtools/config/__init__.py
@@ -1,8 +1,7 @@
-from ._config import Config, cfg
+from ._config import cfg
 from ._variables import var_lookup
 
 __all__ = [
     'cfg',
-    'Config',
     'var_lookup',
 ]

--- a/src/duqtools/config/_config.py
+++ b/src/duqtools/config/_config.py
@@ -6,9 +6,13 @@ from ..schema.cli import ConfigModel
 class Config(ConfigModel):
     """Config class containing all configs, can be used with:
 
-    from duqtools.config import cfg; cfg.<variable you want>
-    """
+        from duqtools.config import cfg
+        cfg.<variable you want>
 
+    To update the config:
+
+        cfg.parse_file('duqtools.yaml')
+    """
     _instance = None
 
     def __new__(cls, *args, **kwargs):
@@ -18,4 +22,4 @@ class Config(ConfigModel):
         return Config._instance
 
 
-cfg = Config()
+cfg = Config.construct()

--- a/src/duqtools/schema/_dimensions.py
+++ b/src/duqtools/schema/_dimensions.py
@@ -36,8 +36,7 @@ class OperatorMixin(BaseModel):
 
 
 class DimMixin(BaseModel):
-    values: Union[List[float], ARange, LinSpace] = Field([1.1, 1.2, 1.3],
-                                                         description=f("""
+    values: Union[List[float], ARange, LinSpace] = Field(description=f("""
             Values to use with operator on field to create sampling
             space."""))
 

--- a/src/duqtools/schema/_imas.py
+++ b/src/duqtools/schema/_imas.py
@@ -9,10 +9,10 @@ from ._basemodel import BaseModel
 
 class ImasBaseModel(BaseModel):
     """This model describes an IMAS data location."""
-    user: str = Field(None, description='Username.')
-    db: str = Field(None, description='IMAS db/machine name.')
-    shot: int = Field(None, description='IMAS Shot number.')
-    run: int = Field(None, description='IMAS Run number.')
+    user: str = Field(description='Username.')
+    db: str = Field(description='IMAS db/machine name.')
+    shot: int = Field(description='IMAS Shot number.')
+    run: int = Field(description='IMAS Run number.')
 
     @validator('user', pre=True, always=True)
     def validate_user(cls, v):

--- a/src/duqtools/schema/_imas.py
+++ b/src/duqtools/schema/_imas.py
@@ -9,7 +9,7 @@ from ._basemodel import BaseModel
 
 class ImasBaseModel(BaseModel):
     """This model describes an IMAS data location."""
-    user: str = Field(description='Username.')
+    user: str = Field(None, description='Username.')
     db: str = Field(description='IMAS db/machine name.')
     shot: int = Field(description='IMAS Shot number.')
     run: int = Field(description='IMAS Run number.')

--- a/src/duqtools/schema/_jetto.py
+++ b/src/duqtools/schema/_jetto.py
@@ -10,14 +10,14 @@ from ._description_helpers import formatter as f
 
 
 class JsetField(BaseModel):
-    file: Literal['jetto.jset'] = Field('jetto.jset')
-    field: str = Field('EquilEscoRefPanel.refMajorRadius')
+    file: Literal['jetto.jset'] = 'jetto.jset'
+    field: str
 
 
 class NamelistField(BaseModel):
-    file: Literal['jetto.in'] = Field('jetto.in')
-    field: str = Field('RMJ')
-    section: str = Field('NLIST1')
+    file: Literal['jetto.in'] = 'jetto.in'
+    field: str
+    section: str
 
     @validator('section')
     def section_lower(cls, v):
@@ -29,13 +29,11 @@ JettoField = Annotated[Union[JsetField, NamelistField],
 
 
 class JettoVar(BaseModel):
-    doc: str = Field('Reference major radius (R0)')
-    name: str = Field('major_radius')
-    type: Literal['str', 'int', 'float'] = Field('float')
-    keys: List[JettoField] = Field(
-        [JsetField(), NamelistField()],
-        description=f(
-            """keys to update when this jetto variable is requested"""))
+    doc: str
+    name: str
+    type: Literal['str', 'int', 'float']
+    keys: List[JettoField] = Field(description=f(
+        """keys to update when this jetto variable is requested"""))
 
     def get_type(self):
         return {

--- a/src/duqtools/schema/_ranges.py
+++ b/src/duqtools/schema/_ranges.py
@@ -9,9 +9,9 @@ class LinSpace(BaseModel):
 
     See the implementation of [numpy.linspace][] for more details.
     """
-    start: float = Field(None, description='Start value of the sequence.')
-    stop: float = Field(None, description='End value of the sequence.')
-    num: int = Field(None, description='Number of samples to generate.')
+    start: float = Field(description='Start value of the sequence.')
+    stop: float = Field(description='End value of the sequence.')
+    num: int = Field(description='Number of samples to generate.')
 
     @property
     def values(self):
@@ -29,10 +29,10 @@ class ARange(BaseModel):
     """
 
     start: float = Field(
-        None, description='Start of the interval. Includes this value.')
+        description='Start of the interval. Includes this value.')
     stop: float = Field(
-        None, description='End of the interval. Excludes this interval.')
-    step: float = Field(None, description='Spacing between values.')
+        description='End of the interval. Excludes this interval.')
+    step: float = Field(description='Spacing between values.')
 
     @property
     def values(self):

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -1,6 +1,5 @@
-from getpass import getuser
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 from pydantic import DirectoryPath, Field
 from typing_extensions import Literal
@@ -18,13 +17,7 @@ from .workdir import WorkDirectoryModel
 class CreateConfigModel(BaseModel):
     """The options of the `create` subcommand are stored in the `create` key in
     the config."""
-    dimensions: List[Union[CoupledDim, OperationDim]] = Field([
-        OperationDim(variable='t_i_average'),
-        OperationDim(variable='zeff'),
-        OperationDim(
-            variable='major_radius', values=[296, 297], operator='copyto')
-    ],
-                                                              description=f("""
+    dimensions: List[Union[CoupledDim, OperationDim]] = Field(description=f("""
         The `dimensions` specifies the dimensions of the matrix to sample
         from. Each dimension is a compound set of operations to apply.
         From this, a matrix all possible combinations is generated.
@@ -48,9 +41,7 @@ class CreateConfigModel(BaseModel):
         Where `n_samples` gives the number of samples to extract.
         """))
 
-    template: DirectoryPath = Field(
-        f'/pfs/work/{getuser()}/jetto/runs/duqtools_template',
-        description=f("""
+    template: DirectoryPath = Field(description=f("""
         Template directory to modify. Duqtools copies and updates the settings
         required for the specified system from this directory. This can be a
         directory with a finished run, or one just stored by JAMS (but not yet
@@ -59,15 +50,13 @@ class CreateConfigModel(BaseModel):
         the UQ runs.
         """))
 
-    template_data: ImasBaseModel = Field(None,
-                                         description=f("""
+    template_data: Optional[ImasBaseModel] = Field(description=f("""
         Specify the location of the template data to modify. This overrides the
         location of the data specified in settings file in the template
         directory.
         """))
 
-    data: DataLocation = Field(DataLocation(),
-                               description=f("""
+    data: DataLocation = Field(description=f("""
         Where to store the in/output IDS data.
         The data key specifies the machine or imas
         database name where to store the data (`imasdb`). duqtools will write the input
@@ -188,23 +177,11 @@ class MergeConfigModel(BaseModel):
                        description=f("""
             Data file with IMAS handles, such as `data.csv` or `runs.yaml`'
             """))
-    template: ImasBaseModel = Field(
-        {
-            'user': getuser(),
-            'db': 'jet',
-            'shot': 94785,
-            'run': 1
-        },
-        description=f("""
+    template: ImasBaseModel = Field(description=f("""
             This IMAS DB entry will be used as the template.
             It is copied to the output location.
             """))
     output: ImasBaseModel = Field(
-        {
-            'db': 'jet',
-            'shot': 94785,
-            'run': 9999
-        },
         description='Merged data will be written to this IMAS DB entry.')
     plan: List[MergeStep] = Field([MergeStep()],
                                   description='List of merging operations.')
@@ -212,28 +189,26 @@ class MergeConfigModel(BaseModel):
 
 class ConfigModel(BaseModel):
     """The options for the CLI are defined by this model."""
-    plot: dict = Field(None,
-                       deprecated=True,
-                       description='Options are specified via CLI.',
-                       exclude=True)
-
     submit: SubmitConfigModel = Field(
         SubmitConfigModel(),
         description='Configuration for the submit subcommand')
-    create: CreateConfigModel = Field(
-        CreateConfigModel(),
+
+    create: Optional[CreateConfigModel] = Field(
         description='Configuration for the create subcommand')
+
     status: StatusConfigModel = Field(
         StatusConfigModel(),
         description='Configuration for the status subcommand')
-    merge: MergeConfigModel = Field(
-        MergeConfigModel(),
+
+    merge: Optional[MergeConfigModel] = Field(
         description='Configuration for the merge subcommand')
 
-    workspace: WorkDirectoryModel = WorkDirectoryModel()
+    workspace: WorkDirectoryModel
+
     system: Literal['jetto', 'dummy', 'jetto-pythontools',
                     'jetto-duqtools'] = Field(
                         'jetto', description='backend system to use')
+
     quiet: bool = Field(
         False,
         description='dont output to stdout, except for mandatory prompts')

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -28,7 +28,7 @@ class CreateConfigModel(BaseModel):
         """))
 
     sampler: Union[LHSSampler, HaltonSampler, SobolSampler,
-                   CartesianProduct] = Field(default=LHSSampler(),
+                   CartesianProduct] = Field(default=CartesianProduct(),
                                              discriminator='method',
                                              description=f("""
         For efficient UQ, it may not be necessary to sample the entire matrix

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -140,23 +140,20 @@ class MergeStep(BaseModel):
     Note that multiple merge steps can be specified, for example for different
     IDS.
     """
-    data_variables: List[str] = Field(['t_i_average', 'zeff'],
-                                      description=f("""
+    data_variables: List[str] = Field(description=f("""
             This is a list of data variables to be merged. This means
             that the mean and error for these data over all runs are calculated
             and written back to the ouput data location.
             The paths should contain `/*/` for the time component or other dimensions.
             """))
-    grid_variable: str = Field('rho_tor_norm',
-                               description=f("""
+    grid_variable: str = Field(description=f("""
             This variable points to the data for the grid coordinate. It must share a common
             placeholder dimension with the data variables.
             It will be used to rebase all data variables to same (radial) grid before merging
             using interpolation.
             The path should contain '/*/' to denote the time component or other dimension.
             """))
-    time_variable: str = Field('time',
-                               description=f("""
+    time_variable: str = Field(description=f("""
             This variable determines the time coordinate to merge on. This ensures
             that the data from all runs are on the same time coordinates before
             merging.
@@ -183,8 +180,7 @@ class MergeConfigModel(BaseModel):
             """))
     output: ImasBaseModel = Field(
         description='Merged data will be written to this IMAS DB entry.')
-    plan: List[MergeStep] = Field([MergeStep()],
-                                  description='List of merging operations.')
+    plan: List[MergeStep] = Field(description='List of merging operations.')
 
 
 class ConfigModel(BaseModel):

--- a/src/duqtools/schema/data_location.py
+++ b/src/duqtools/schema/data_location.py
@@ -26,14 +26,12 @@ class DataLocation(BaseModel):
     will stop if it detects that data will be overwritten.
     """
 
-    imasdb: str = Field('test', description='IMAS database or machine name.')
+    imasdb: str = Field(description='IMAS database or machine name.')
 
-    run_in_start_at: int = Field(7000,
-                                 description=f("""
+    run_in_start_at: int = Field(description=f("""
             The sequence of input data files start with this run number.
             """))
 
-    run_out_start_at: int = Field(8000,
-                                  description=f("""
+    run_out_start_at: int = Field(description=f("""
             The sequence of output data files start with this run number.
             """))

--- a/src/duqtools/schema/runs.py
+++ b/src/duqtools/schema/runs.py
@@ -10,7 +10,7 @@ from ._imas import ImasBaseModel
 
 
 class Run(BaseModel):
-    dirname: DirectoryPath = Field(..., description='Directory of run')
+    dirname: DirectoryPath = Field(description='Directory of run')
     data_in: ImasBaseModel
     data_out: ImasBaseModel
     operations: List[Union[IDSOperation, JettoOperation,

--- a/src/duqtools/schema/runs.py
+++ b/src/duqtools/schema/runs.py
@@ -10,7 +10,7 @@ from ._imas import ImasBaseModel
 
 
 class Run(BaseModel):
-    dirname: DirectoryPath = Field(None, description='Directory of run')
+    dirname: DirectoryPath = Field(..., description='Directory of run')
     data_in: ImasBaseModel
     data_out: ImasBaseModel
     operations: List[Union[IDSOperation, JettoOperation,

--- a/src/duqtools/schema/workdir.py
+++ b/src/duqtools/schema/workdir.py
@@ -1,5 +1,3 @@
-from getpass import getuser
-
 from pydantic import DirectoryPath, Field
 
 from ._basemodel import BaseModel
@@ -14,11 +12,10 @@ class WorkDirectoryModel(BaseModel):
     a subdirectory of the given root directory. All subdirectories are
     calculated as relative to the root directory.
 
-    For example, for `rjettov`, the root directory is set to
+    For example, for `rjettov`, the root directory must be set to
     `/pfs/work/$USER/jetto/runs/`. Any UQ runs must therefore be
     a subdirectory.
     """
 
     root: DirectoryPath = Field(
-        f'/pfs/work/{getuser()}/jetto/runs/',
         description='The directory from which experiments have to be run.')


### PR DESCRIPTION
Removes some of the defaults from the code that are too specific to either the gateway or our personal usernames or setups.

- The example duqtools.yaml is a good starting point
- We simply copy the default duqtools.yaml, so we no longer need to mix example settings with default values
- More of the code is accessible without a config file
- Necessary configs are not accidentally filled by default values that make sense for a specific situation or setup

Addresses #311