### PR TITLE
Update `duqtools clean` to remove slurm array files

### DIFF
--- a/src/duqtools/models/_workdir.py
+++ b/src/duqtools/models/_workdir.py
@@ -42,7 +42,6 @@ class WorkDirectory(WorkDirectoryModel):
         runs_yaml = self.runs_yaml
 
         if not runs_yaml.exists():
-            raise IOError(
-                f'Cannot find {runs_yaml}, therefore cannot show the status')
+            raise IOError(f'Cannot find {runs_yaml}.')
 
         return Runs.parse_file(runs_yaml)

--- a/src/duqtools/operations.py
+++ b/src/duqtools/operations.py
@@ -97,18 +97,17 @@ class Operations(deque):
             Operations._instance = super().__new__(cls)
         return Operations._instance
 
-    def add(self, *args, **kwargs) -> None:
+    def add(self, **kwargs) -> None:
         """convenience Operation wrapper around put.
 
         ```python
         from duqtools.operations import add_to_op_queue.
 
-        op_queue.add(print, args=('Hello World,),
+        op_queue.add(action=print, args=('Hello World,),
                 description="Function that prints hello world")
         ```
         """
-
-        self.append(Operation(*args, **kwargs))
+        self.append(Operation(**kwargs))
 
     def put(self, item: Operation) -> None:
         """synonym for append."""
@@ -207,9 +206,9 @@ def confirm_operations(func):
 
     @confirm_operations
     def complicated_stuff()
-        op_queue.add(print, args=('Hello World,),
+        op_queue.add(action=print, args=('Hello World,),
                 description="Function that prints hello world")
-        op_queue.add(print, args=('Hello World again,),
+        op_queue.add(action=print, args=('Hello World again,),
                 description="Function that prints hello world, again")
     ```
     """

--- a/src/duqtools/plot.py
+++ b/src/duqtools/plot.py
@@ -66,7 +66,7 @@ def create_chart(n, x_var, y_var, dataset, extensions):
         outfile = Path(f'chart_{n}.{extension}')
         click.secho(f'    file:///{outfile.absolute()}', bold=True)
 
-        op_queue.add(chart.save,
+        op_queue.add(action=chart.save,
                      args=(outfile, ),
                      kwargs={'scale_factor': 2.0},
                      description='Saving chart',


### PR DESCRIPTION
This PR adds the slurm array files to the clean up list. Also refactors the `Operation` class to colorize op without extra_description.

Closes #345 