### PR TITLE
Patch jetto.jset during create to always write IDS files

### DIFF
--- a/src/duqtools/cleanup.py
+++ b/src/duqtools/cleanup.py
@@ -5,8 +5,6 @@ import os
 import shutil
 from pathlib import Path
 
-import click
-
 from .config import cfg
 from .ids import ImasHandle
 from .models import WorkDirectory
@@ -51,11 +49,8 @@ def cleanup(out, force, **kwargs):
         if out:
             data_out.delete()
         else:
-            op_queue.add(action=lambda: None,
-                         description=click.style('NOT Removing',
-                                                 fg='red',
-                                                 bold=True),
-                         extra_description=f'{data_out}')
+            op_queue.add_no_op(description='NOT Removing',
+                               extra_description=f'{data_out}')
 
         if (Path(run.dirname).exists()):
             op_queue.add(

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Iterable
 
-import click
 import pandas as pd
 
 from .apply_model import apply_model
@@ -25,11 +24,9 @@ def any_locations_exist(locations: Iterable[ImasHandle]):
     for location in locations:
         if location.exists():
             logger.info('Target %s already exists', location)
-            op_queue.add(action=lambda: None,
-                         description=click.style('Not creating IDS',
-                                                 fg='red',
-                                                 bold=True),
-                         extra_description=f'IDS entry {location} exists')
+            op_queue.add_no_op(
+                description='Not creating IDS',
+                extra_description=f'IDS entry {location} exists')
             any_exists = True
     if any_exists:
         return True
@@ -95,11 +92,9 @@ def create(*, force, **kwargs):
     targets_exist = False
     if not force:
         if workspace.runs_yaml.exists():
-            op_queue.add(action=lambda: None,
-                         description=click.style('Not creating runs.yaml',
-                                                 fg='red',
-                                                 bold=True),
-                         extra_description=f'{workspace.runs_yaml} exists')
+            op_queue.add_no_op(
+                description='Not creating runs.yaml',
+                extra_description=f'{workspace.runs_yaml} exists')
             targets_exist = True
 
         locations = (ImasHandle(db=options.data.imasdb,
@@ -118,25 +113,21 @@ def create(*, force, **kwargs):
             run_drc = workspace.cwd / run_name
 
             if run_drc.exists():
-                op_queue.add(action=lambda: None,
-                             description=click.style('Not creating directory',
-                                                     fg='red',
-                                                     bold=True),
-                             extra_description=f'Directory {run_drc} exists')
+                op_queue.add_no_op(
+                    description='Not creating directory',
+                    extra_description=f'Directory {run_drc} exists',
+                )
                 targets_exist = True
 
-# do one final check if we will not overwrite existing files
+    # Do one final check if we will not overwrite existing files
+
     if targets_exist and not force:
-        op_queue.add(action=lambda: None,
-                     description=click.style('Not creating runs',
-                                             fg='red',
-                                             bold=True),
-                     extra_description='some targets already exist, '
-                     'use --force to override')
+        op_queue.add_no_op(description='Not creating runs',
+                           extra_description='some targets already exist, '
+                           'use --force to override')
         return
 
-
-# end safety checks
+    # End safety checks
 
     for i, combination in enumerate(combinations):
         run_name = f'{RUN_PREFIX}{i:04d}'

--- a/src/duqtools/submit.py
+++ b/src/duqtools/submit.py
@@ -5,8 +5,6 @@ from itertools import cycle
 from pathlib import Path
 from typing import Deque, Sequence, Tuple
 
-import click
-
 from ._logging_utils import duqlog_screen
 from .config import cfg
 from .models import Job, WorkDirectory
@@ -103,11 +101,9 @@ def status_file_ok(job, *, force):
         with open(status_file, 'r') as f:
             info('Status of %s: %s. To rerun enable the --force flag',
                  status_file, f.read())
-        op_queue.add(action=lambda: None,
-                     description=click.style('Not Submitting',
-                                             fg='red',
-                                             bold=True),
-                     extra_description=f'{job} (reason: status file exists)')
+        op_queue.add_no_op(
+            description='Not Submitting',
+            extra_description=f'{job} (reason: status file exists)')
         return False
 
     return True
@@ -116,11 +112,9 @@ def status_file_ok(job, *, force):
 def lockfile_ok(job, *, force):
     lockfile = job.lockfile
     if lockfile.exists() and not force:
-        op_queue.add(action=lambda: None,
-                     description=click.style('Not Submitting',
-                                             fg='red',
-                                             bold=True),
-                     extra_description=f'{job} (reason: {lockfile} exists)')
+        op_queue.add_no_op(
+            description='Not Submitting',
+            extra_description=f'{job} (reason: {lockfile} exists)')
         return False
 
     return True
@@ -167,15 +161,11 @@ def submit(*, force: bool, max_jobs: int, schedule: bool, array: bool,
         job_queue.append(job)
 
     if array and Path('./duqtools_slurm_array.sh').exists() and not force:
-        op_queue.add(
-            action=lambda: None,
-            description=click.style('Not Creating Array', fg='red', bold=True),
+        op_queue.add_no_op(
+            description='Not Creating Array',
             extra_description='(reason: duqtools_slurm_array.sh exists)')
-        op_queue.add(action=lambda: None,
-                     description=click.style('Not Submitting Array',
-                                             fg='red',
-                                             bold=True),
-                     extra_description='use --force to override')
+        op_queue.add_no_op(description='Not Submitting Array',
+                           extra_description='use --force to override')
         return
 
     submitter = job_scheduler if schedule else job_submitter


### PR DESCRIPTION
This PR patches the `jetto.jset` to always write IDS files. It also refactors how operations are added to the queue and handles the style application in the queue module.

Closes #343