### PR TITLE
Add cli command to recreate run from `runs.yaml`

### DIFF
--- a/src/duqtools/apply_model.py
+++ b/src/duqtools/apply_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import abc
 from functools import singledispatch
 from pathlib import Path
 
@@ -7,7 +8,7 @@ from .schema import BaseModel, JettoOperation
 
 
 @singledispatch
-def apply_model(model: BaseModel, **kwargs) -> None:
+def apply_model(model: BaseModel, **kwargs):
     """Apply operation in model to target. Data are modified in-place.
 
     Parameters
@@ -20,21 +21,20 @@ def apply_model(model: BaseModel, **kwargs) -> None:
     NotImplementedError
         When the model is unknown
     """
-
     raise NotImplementedError(f'Unknown model: {model}')
 
 
 @apply_model.register
-def _apply_coupled(model: tuple, **kwargs) -> None:  # type: ignore
-    for mode in model:
-        apply_model(mode, **kwargs)
+def _apply_coupled(model: abc.Iterable, **kwargs):  # type: ignore
+    for submodel in model:
+        apply_model(submodel, **kwargs)
 
 
 from .ids._apply_model import _apply_ids  # noqa: E402, F401
 
 
 @apply_model.register
-def _apply_jetto(model: JettoOperation, run_dir: Path, **kwargs) -> None:
+def _apply_jetto(model: JettoOperation, run_dir: Path, **kwargs):
     from .system import get_system
     system = get_system()
     system.set_jetto_variable(run_dir, model.variable.name, model.value,

--- a/src/duqtools/cleanup.py
+++ b/src/duqtools/cleanup.py
@@ -43,7 +43,7 @@ def cleanup(out, force, **kwargs):
     """
     try:
         workspace = WorkDirectory.parse_obj(cfg.workspace)
-        runs = workspace.construct_runs
+        runs = workspace.runs
     except OSError:
         runs = ()
     else:

--- a/src/duqtools/cleanup.py
+++ b/src/duqtools/cleanup.py
@@ -9,6 +9,7 @@ from .config import cfg
 from .ids import ImasHandle
 from .models import WorkDirectory
 from .operations import op_queue
+from .schema.runs import Run
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,17 @@ def remove_files(*filenames: str):
             os.unlink(filename)
         except FileNotFoundError:
             pass
+
+
+def remove_run(model: Run):
+    """Remove run directory if it exists."""
+    if Path(model.dirname).exists():
+        op_queue.add(
+            action=shutil.rmtree,
+            args=(model.dirname, ),
+            description='Removing run dir',
+            extra_description=f'{model.dirname}',
+        )
 
 
 def cleanup(out, force, **kwargs):
@@ -52,13 +64,7 @@ def cleanup(out, force, **kwargs):
             op_queue.add_no_op(description='NOT Removing',
                                extra_description=f'{data_out}')
 
-        if (Path(run.dirname).exists()):
-            op_queue.add(
-                action=shutil.rmtree,
-                args=(run.dirname, ),
-                description='Removing run dir',
-                extra_description=f'{run.dirname}',
-            )
+        remove_run(run)
 
     op_queue.add(
         action=shutil.move,

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -183,9 +183,6 @@ def cli_create(**kwargs):
 
 @cli.command('recreate')
 @click.argument('runs', nargs=-1)
-@click.option('--force',
-              is_flag=True,
-              help='Overwrite existing run directories and IDS data.')
 @common_options
 def cli_recreate(**kwargs):
     """Read `runs.yaml` and re-create the given runs.

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -181,6 +181,24 @@ def cli_create(**kwargs):
         create(**kwargs)
 
 
+@cli.command('recreate')
+@click.argument('runs', nargs=-1)
+@click.option('--force',
+              is_flag=True,
+              help='Overwrite existing run directories and IDS data.')
+@common_options
+def cli_recreate(**kwargs):
+    """Read `runs.yaml` and re-create the given runs.
+
+    Example:
+    \b
+    - duqtools recreate run_0003 run_0004 --force
+    """
+    from .create import recreate
+    with op_queue_context():
+        recreate(**kwargs)
+
+
 @cli.command('submit')
 @click.option('--force',
               is_flag=True,

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -129,7 +129,7 @@ class RunCreator:
         for model in combination:
             apply_model(model, run_dir=run_dir, ids_mapping=data_in)
 
-    @add_to_op_queue('Writing runs', '{workspace.runs_yaml}', quiet=True)
+    @add_to_op_queue('Writing runs', '{self.workspace.runs_yaml}', quiet=True)
     def write_runs_file(self, runs: Sequence[Run]) -> None:
         runs = Runs.parse_obj(runs)
         with open(self.workspace.runs_yaml, 'w') as f:

--- a/src/duqtools/models/_workdir.py
+++ b/src/duqtools/models/_workdir.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import List
 
-import yaml
 from pydantic import validator
 
 from ..schema.runs import Run, Runs
@@ -46,16 +45,3 @@ class WorkDirectory(WorkDirectoryModel):
             raise IOError(f'Cannot find {runs_yaml}.')
 
         return Runs.parse_file(runs_yaml)
-
-    @property
-    def construct_runs(self) -> List[Run]:
-        """Get list, but don't validate its validity."""
-        runs_yaml = self.runs_yaml
-
-        if not runs_yaml.exists():
-            raise IOError(f'Cannot find {runs_yaml}.')
-
-        with open(runs_yaml, 'r') as f:
-            runs = yaml.load(f, Loader=yaml.Loader)
-
-        return Runs.construct(runs)

--- a/src/duqtools/operations.py
+++ b/src/duqtools/operations.py
@@ -197,11 +197,17 @@ class Operations(deque):
             duqlog_screen.info('Dry run enabled, not applying op_queue')
             return False
 
+        # Do not confirm if all actions are no-op
+        if all(op.action is None for op in self):
+            duqlog_screen.info('\nNo actions to execute.')
+            return False
+
         ans = self.yes or click.confirm(
-            'Do you want to apply all these operations?', default=False)
+            '\nDo you want to apply all these operations?', default=False)
 
         if ans:
             self.apply_all()
+
         return ans
 
     def check_unconfirmed_operations(self):

--- a/src/duqtools/schema/runs.py
+++ b/src/duqtools/schema/runs.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Union
 
-from pydantic import DirectoryPath, Field
+from pydantic import Field
 
 from ._basemodel import BaseModel
 from ._dimensions import IDSOperation, JettoOperation
@@ -10,7 +11,7 @@ from ._imas import ImasBaseModel
 
 
 class Run(BaseModel):
-    dirname: DirectoryPath = Field(description='Directory of run')
+    dirname: Path = Field(description='Directory of run')
     data_in: ImasBaseModel
     data_out: ImasBaseModel
     operations: List[Union[IDSOperation, JettoOperation,

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -57,6 +57,15 @@ def test_example_create(cmdline_workdir):
 
 
 @pytest.mark.dependency()
+def test_example_recreate(cmdline_workdir):
+    cmd = 'duqtools recreate run_0000 -c config.yaml --yes'.split()
+
+    with work_directory(cmdline_workdir):
+        result = sp.run(cmd)
+        assert (result.returncode == 0)
+
+
+@pytest.mark.dependency()
 def test_example_submit(cmdline_workdir, system, request):
     depends(request, [f'test_example_create[{system}]'])
 


### PR DESCRIPTION
This PR adds a new subcommand to recreate a run from `runs.yaml`.

Closes #339 

### Todo
- [x] Refactor create.py to share code between `create()` and `recreate()`
- [x] Convert to ImasHandle in `recreate`
- [x] Revise method and class names
- [x] Pass tests (if necessary)